### PR TITLE
[task_enrich] Ensure number of enrich tasks decreases upon failure

### DIFF
--- a/mordred/task_enrich.py
+++ b/mordred/task_enrich.py
@@ -252,15 +252,18 @@ class TaskEnrich(Task):
                                      self.backend_section)
         #  ** END SYNC LOGIC **
 
-        self.__enrich_items()
+        try:
+            self.__enrich_items()
 
-        if cfg['es_enrichment']['autorefresh']:
-            logger.debug("Doing autorefresh for %s", self.backend_section)
-            self.__autorefresh()
-        else:
-            logger.debug("Not doing autorefresh for %s", self.backend_section)
+            if cfg['es_enrichment']['autorefresh']:
+                logger.debug("Doing autorefresh for %s", self.backend_section)
+                self.__autorefresh()
+            else:
+                logger.debug("Not doing autorefresh for %s", self.backend_section)
 
-        self.__studies()
-
-        with TasksManager.NUMBER_ENRICH_TASKS_ON_LOCK:
-            TasksManager.NUMBER_ENRICH_TASKS_ON -= 1
+            self.__studies()
+        except Exception as e:
+            raise e
+        finally:
+            with TasksManager.NUMBER_ENRICH_TASKS_ON_LOCK:
+                TasksManager.NUMBER_ENRICH_TASKS_ON -= 1

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -35,7 +35,7 @@ from mordred.task import Task
 
 CONF_FILE = 'test.cfg'
 BACKEND_NAME = 'stackexchange'
-COLLECTION_URL = 'http://localhost:9200'
+COLLECTION_URL = 'http://bitergia:bitergia@localhost:9200'
 COLLECTION_URL_STACKEXCHANGE = 'http://127.0.0.1:9200'
 REPO_NAME = 'https://stackoverflow.com/questions/tagged/ovirt'
 


### PR DESCRIPTION
This patch ensures that the variable `NUMBER_ENRICH_TASKS_ON` decreases in case of failures when executing enrichment tasks. Thus. it avoids possible infinite loops when loading identities.