### PR TITLE
Enable study conf for backends via .cfg

### DIFF
--- a/mordred/config.py
+++ b/mordred/config.py
@@ -590,6 +590,14 @@ class Config():
         return gelk_backends + extra_backends
 
     @classmethod
+    def get_study_sections(cls):
+        # a study name could include and extra ":<param>"
+        # to have several backend entries with different configs
+        studies = ("enrich_demography", "enrich_areas_of_code", "enrich_onion")
+
+        return studies
+
+    @classmethod
     def get_global_data_sources(cls):
         """ Data sources than are collected and enriched globally """
 
@@ -610,10 +618,13 @@ class Config():
         # First let's check all common sections entries
         check_params = cls.general_params()
         backend_sections = cls.get_backend_sections()
+        study_sections = cls.get_study_sections()
 
         for section in config.keys():
             if section in backend_sections or section[1:] in backend_sections:
                 # backend_section or *backend_section, to be checked later
+                continue
+            if section.startswith((study_sections)):
                 continue
             if section not in check_params.keys():
                 raise RuntimeError("Wrong section:", section)

--- a/tests/test.cfg
+++ b/tests/test.cfg
@@ -103,7 +103,19 @@ user = acs
 [git]
 raw_index = git_test-raw
 enriched_index = git_test
-studies = [enrich_demography]
+
+[enrich_demography:1]
+no_incremental = true
+
+[enrich_areas_of_code]
+in_index = git_test-raw
+out_index = git_test-aoc
+
+[enrich_onion]
+in_index = git_test
+out_index = git_test-onion
+contribs_field = hash
+no_incremental = true
 
 [github]
 raw_index = github_test-raw

--- a/tests/test_task_enrich.py
+++ b/tests/test_task_enrich.py
@@ -33,6 +33,7 @@ from sortinghat.db.database import Database
 sys.path.insert(0, '..')
 
 from mordred.config import Config
+from mordred.error import DataEnrichmentError
 from mordred.task_projects import TaskProjects
 from mordred.task_enrich import TaskEnrich
 
@@ -106,24 +107,27 @@ class TestTaskEnrich(unittest.TestCase):
         TaskProjects(config).execute()
         backend_section = GIT_BACKEND_SECTION
         task = TaskEnrich(config, backend_section=backend_section)
-        self.assertEqual(task.execute(), None)
-
-        # Configure a wrong study
-        cfg['git']['studies'] = ['bad_study']
-        with self.assertRaises(RuntimeError):
-            self.assertEqual(task.execute(), None)
 
         # Configure no studies
         cfg['git']['studies'] = None
         self.assertEqual(task.execute(), None)
 
+        # Configure a wrong study
+        cfg['git']['studies'] = ['bad_study']
+        with self.assertRaises(DataEnrichmentError):
+            self.assertEqual(task.execute(), None)
+
         # Configure several studies
-        cfg['git']['studies'] = ["enrich_demography", "enrich_areas_of_code"]
+        cfg['git']['studies'] = ['enrich_onion']
+        self.assertEqual(task.execute(), None)
+
+        # Configure several studies
+        cfg['git']['studies'] = ['enrich_demography:1', 'enrich_areas_of_code']
         self.assertEqual(task.execute(), None)
 
         # Configure several studies, one wrong
-        cfg['git']['studies'] = ["enrich_demography", "enrich_areas_of_code1"]
-        with self.assertRaises(RuntimeError):
+        cfg['git']['studies'] = ['enrich_demography:1', "enrich_areas_of_code1"]
+        with self.assertRaises(DataEnrichmentError):
             self.assertEqual(task.execute(), None)
 
 


### PR DESCRIPTION
This code allows to define sections for studies (onion, demography and areas of code). In any backend section, a list of studies can be declared. Every declared study must have its parameters in a specific cfg section defined by type-of-the-study:study-id (e.g., enrich_onion:1). The id makes possible to execute the same types of studies for a given backend.