### PR TITLE
[studies] Allow setting up kafka_kip via cfg

### DIFF
--- a/mordred/config.py
+++ b/mordred/config.py
@@ -593,7 +593,7 @@ class Config():
     def get_study_sections(cls):
         # a study name could include and extra ":<param>"
         # to have several backend entries with different configs
-        studies = ("enrich_demography", "enrich_areas_of_code", "enrich_onion")
+        studies = ("enrich_demography", "enrich_areas_of_code", "enrich_onion", "kafka_kip")
 
         return studies
 

--- a/tests/test.cfg
+++ b/tests/test.cfg
@@ -151,6 +151,9 @@ project = PUP
 raw_index = mbox_test-raw
 enriched_index = mbox_test
 
+[kafka_kip]
+no_incremental = true
+
 [mediawiki]
 raw_index = mediawiki_test-raw
 enriched_index = mediawiki_test

--- a/tests/test_task_enrich.py
+++ b/tests/test_task_enrich.py
@@ -125,6 +125,10 @@ class TestTaskEnrich(unittest.TestCase):
         cfg['git']['studies'] = ['enrich_demography:1', 'enrich_areas_of_code']
         self.assertEqual(task.execute(), None)
 
+        # Configure kafka kip study
+        cfg['mbox']['studies'] = ['kafka_kip']
+        self.assertEqual(task.execute(), None)
+
         # Configure several studies, one wrong
         cfg['git']['studies'] = ['enrich_demography:1', "enrich_areas_of_code1"]
         with self.assertRaises(DataEnrichmentError):


### PR DESCRIPTION
This code enables to set up the `kafka_kip` study via the mordred configuration file. A test has been added within the test_task_enrich file to ensure the correct execution of study.