### PR TITLE
[studies] Handle empty list of studies in backends

### DIFF
--- a/tests/test-projects.json
+++ b/tests/test-projects.json
@@ -1,49 +1,68 @@
 {
  "grimoire": {
-  "telegram": [
-   "Mozilla_analytics"
+  "askbot": [
+   "https://ask.puppet.com"
   ],
-  "slack": [
-   "C7LSGB0AU"
+  "bugzilla": [
+   "https://bugs.eclipse.org/bugs/"
   ],
-  "github": [
-   "https://github.com/grimoirelab/perceval"
+  "bugzillarest": [
+   "https://bugzilla.mozilla.org"
   ],
   "confluence": [
    "https://wiki.open-o.org/"
+  ],
+  "discourse": [
+   "https://foro.mozilla-hispano.org/"
+  ],
+  "dockerhub": [
+   "bitergia kibiter"
+  ],
+  "functest": [
+   "http://testresults.opnfv.org/test/"
+  ],
+  "gerrit": [
+   "review.openstack.org"
   ],
   "git": [
    "https://github.com/VizGrimoire/GrimoireLib --filters-raw-prefix data.files.file:grimoirelib_alch data.files.file:README.md",
    "https://github.com/MetricsGrimoire/CMetrics"
   ],
-  "gerrit": [
-   "review.openstack.org"
+  "github": [
+   "https://github.com/grimoirelab/perceval"
   ],
-  "meetup": [
-   "South-East-Puppet-User-Group"
+  "google_hits": [
+   ""
   ],
-  "functest": [
-   "http://testresults.opnfv.org/test/"
+  "hyperkitty": [
+   "https://lists.mailman3.org/archives/list/mailman-users@mailman3.org"
   ],
-  "bugzillarest": [
-   "https://bugzilla.mozilla.org"
+  "jenkins": [
+   "https://build.opnfv.org/ci"
+  ],
+  "jira": [
+   "https://jira.opnfv.org"
+  ],
+  "mbox": [
+   "metrics-grimoire ~/.perceval/mbox"
   ],
   "mediawiki": [
    "https://wiki.mozilla.org"
   ],
-  "remo": [
-   "https://reps.mozilla.org"
+  "meetup": [
+   "South-East-Puppet-User-Group"
   ],
-  "dockerhub": [
-   "bitergia kibiter"
+  "mozillaclub": [
+   "https://spreadsheets.google.com/feeds/cells/1QHl2bjBhMslyFzR5XXPzMLdzzx7oeSKTbgR5PM8qp64/ohaibtm/public/values?alt=json"
   ],
-  "stackexchange": [
-   "https://stackoverflow.com/questions/tagged/ovirt",
-   "https://stackoverflow.com/questions/tagged/rdo",
-   "https://stackoverflow.com/questions/tagged/kibana"
+  "nntp": [
+   "news.mozilla.org mozilla.dev.project-link"
   ],
-  "rss": [
-   "https://blog.bitergia.com/feed/"
+  "phabricator": [
+   "https://phabricator.wikimedia.org"
+  ],
+  "pipermail": [
+   "https://mail.gnome.org/archives/libart-hackers/"
   ],
   "puppetforge": [
    ""
@@ -51,47 +70,28 @@
   "redmine": [
    "http://tracker.ceph.com/"
   ],
-  "askbot": [
-   "https://ask.puppet.com"
+  "remo": [
+   "https://reps.mozilla.org"
   ],
-  "mbox": [
-   "metrics-grimoire ~/.perceval/mbox"
+  "rss": [
+   "https://blog.bitergia.com/feed/"
   ],
-  "pipermail": [
-   "https://mail.gnome.org/archives/libart-hackers/"
+  "slack": [
+   "C7LSGB0AU"
   ],
-  "mozillaclub": [
-   "https://spreadsheets.google.com/feeds/cells/1QHl2bjBhMslyFzR5XXPzMLdzzx7oeSKTbgR5PM8qp64/ohaibtm/public/values?alt=json"
-  ],
-  "google_hits": [
-   ""
-  ],
-  "jenkins": [
-   "https://build.opnfv.org/ci"
-  ],
-  "bugzilla": [
-   "https://bugs.eclipse.org/bugs/"
-  ],
-  "twitter": [
-   ""
-  ],
-  "hyperkitty": [
-   "https://lists.mailman3.org/archives/list/mailman-users@mailman3.org"
-  ],
-  "phabricator": [
-   "https://phabricator.wikimedia.org"
+  "stackexchange": [
+   "https://stackoverflow.com/questions/tagged/ovirt",
+   "https://stackoverflow.com/questions/tagged/rdo",
+   "https://stackoverflow.com/questions/tagged/kibana"
   ],
   "supybot": [
    "openshift ~/.perceval/irc/percevalbot/logs/ChannelLogger/freenode/#openshift/"
   ],
-  "nntp": [
-   "news.mozilla.org mozilla.dev.project-link"
+  "telegram": [
+   "Mozilla_analytics"
   ],
-  "jira": [
-   "https://jira.opnfv.org"
-  ],
-  "discourse": [
-   "https://foro.mozilla-hispano.org/"
+  "twitter": [
+   ""
   ]
  }
 }

--- a/tests/test.cfg
+++ b/tests/test.cfg
@@ -103,6 +103,7 @@ user = acs
 [git]
 raw_index = git_test-raw
 enriched_index = git_test
+studies = []
 
 [enrich_demography:1]
 no_incremental = true

--- a/tests/test_task_enrich.py
+++ b/tests/test_task_enrich.py
@@ -112,6 +112,10 @@ class TestTaskEnrich(unittest.TestCase):
         cfg['git']['studies'] = None
         self.assertEqual(task.execute(), None)
 
+        # Configure no studies
+        cfg['git']['studies'] = []
+        self.assertEqual(task.execute(), None)
+
         # Configure a wrong study
         cfg['git']['studies'] = ['bad_study']
         with self.assertRaises(DataEnrichmentError):


### PR DESCRIPTION
This code allows to handle an empty list of studies within a backend section. In a nutshell, studies with empty names are filtered out from the list of studies. In case the filtered list is empty, a warning message is logged to notify the user.