### PR TITLE
[tests] Add arthur and perceval eggs to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 PyMySQL
 pyyaml
 redis
-kingarthur>=0.1.7
 -e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
 -e git+https://github.com/chaoss/grimoirelab-manuscripts/#egg=grimoirelab-manuscripts
 -e git+https://github.com/chaoss/grimoirelab-kidash/#egg=grimoirelab-kidash
 -e git+https://github.com/chaoss/grimoirelab-elk/#egg=grimoirelab-elk
+-e git+https://github.com/chaoss/grimoirelab-perceval/#egg=grimoirelab-perceval
+-e git+https://github.com/chaoss/grimoirelab-kingarthur/#egg=grimoirelab-kingarthur


### PR DESCRIPTION
This code enables the inclusion of arthur and perceval eggs to the requirements.txt, thus allowing to test the full chain of grimoirelab using the master heads of all components.