### PR TITLE
[config] Add tag to backend sections

### DIFF
--- a/tests/test.cfg
+++ b/tests/test.cfg
@@ -127,6 +127,15 @@ archive-path = /tmp/test_github_archive
 category = issue
 sleep-time = 300
 
+[github:pull]
+raw_index = github_test-raw-pull
+enriched_index = github_test-pull
+api-token = XXXXX
+sleep-for-rate = true
+archive-path = /tmp/test_github_archive
+category = pull_request
+sleep-time = 300
+
 [google_hits]
 # logstash
 collect = false

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+
+import sys
+import tempfile
+import unittest
+
+# Hack to make sure that tests import the right packages
+# due to setuptools behaviour
+sys.path.insert(0, '..')
+
+from sirmordred.config import (Config, logger)
+
+CONF_FILE = 'test.cfg'
+CONF_STUDIES = 'test_studies.cfg'
+CONF_WRONG = 'test_wrong.cfg'
+
+
+class TestConfig(unittest.TestCase):
+    """Config tests"""
+
+    def test_init(self):
+        """Test whether attributes are initializated"""
+
+        config = Config(CONF_FILE)
+
+        self.assertIsNotNone(config.conf)
+        self.assertIsNone(config.raw_conf)
+        self.assertEqual(config.conf_list, [CONF_FILE])
+        self.assertEqual(len(config.conf.keys()), 42)
+
+    def test_init_studies(self):
+        """Test whether studies' attributes are initializated"""
+
+        config = Config(CONF_STUDIES)
+
+        self.assertIsNotNone(config.conf)
+        self.assertIsNone(config.raw_conf)
+        self.assertEqual(config.conf_list, [CONF_STUDIES])
+        self.assertEqual(len(config.conf.keys()), 13)
+
+        self.assertTrue('general' in config.conf.keys())
+        self.assertTrue('projects' in config.conf.keys())
+        self.assertTrue('es_collection' in config.conf.keys())
+        self.assertTrue('es_enrichment' in config.conf.keys())
+        self.assertTrue('sortinghat' in config.conf.keys())
+        self.assertTrue('panels' in config.conf.keys())
+        self.assertTrue('phases' in config.conf.keys())
+
+        self.assertTrue('git' in config.conf.keys())
+        self.assertTrue('enrich_demography:git' in config.conf.keys())
+        self.assertTrue('no_incremental' in config.conf['enrich_demography:git'].keys())
+
+        self.assertTrue('enrich_areas_of_code:git' in config.conf.keys())
+        self.assertTrue('in_index' in config.conf['enrich_areas_of_code:git'].keys())
+        self.assertTrue('out_index' in config.conf['enrich_areas_of_code:git'].keys())
+        self.assertTrue('sort_on_field' in config.conf['enrich_areas_of_code:git'].keys())
+        self.assertTrue('no_incremental' in config.conf['enrich_areas_of_code:git'].keys())
+
+        self.assertTrue('enrich_onion:git' in config.conf.keys())
+        self.assertTrue('in_index' in config.conf['enrich_onion:git'].keys())
+        self.assertTrue('out_index' in config.conf['enrich_onion:git'].keys())
+        self.assertTrue('data_source' in config.conf['enrich_onion:git'].keys())
+        self.assertTrue('contribs_field' in config.conf['enrich_onion:git'].keys())
+        self.assertTrue('timeframe_field' in config.conf['enrich_onion:git'].keys())
+        self.assertTrue('sort_on_field' in config.conf['enrich_onion:git'].keys())
+        self.assertTrue('no_incremental' in config.conf['enrich_onion:git'].keys())
+
+        self.assertTrue('github' in config.conf.keys())
+        self.assertTrue('enrich_onion:github' in config.conf.keys())
+        self.assertTrue('in_index_iss' in config.conf['enrich_onion:github'].keys())
+        self.assertTrue('in_index_prs' in config.conf['enrich_onion:github'].keys())
+        self.assertTrue('out_index_iss' in config.conf['enrich_onion:github'].keys())
+        self.assertTrue('in_index_prs' in config.conf['enrich_onion:github'].keys())
+        self.assertTrue('data_source_iss' in config.conf['enrich_onion:github'].keys())
+        self.assertTrue('data_source_prs' in config.conf['enrich_onion:github'].keys())
+        self.assertTrue('contribs_field' in config.conf['enrich_onion:github'].keys())
+        self.assertTrue('timeframe_field' in config.conf['enrich_onion:github'].keys())
+        self.assertTrue('sort_on_field' in config.conf['enrich_onion:github'].keys())
+        self.assertTrue('no_incremental' in config.conf['enrich_onion:github'].keys())
+
+    def test_create_config_file(self):
+        """Test whether a config file is correctly created"""
+
+        tmp_path = tempfile.mktemp(prefix='mordred_')
+
+        config = Config(CONF_FILE)
+        config.create_config_file(tmp_path)
+        copied_config = Config(tmp_path)
+        # TODO create_config_file produces a config different from the original one
+        # self.assertDictEqual(config.conf, copied_config.conf)
+
+    def test_check_config(self):
+        """Test whether the config is properly checked"""
+
+        with self.assertRaises(Exception):
+            Config(CONF_WRONG)
+
+    def test_get_data_sources(self):
+        """Test whether all data sources are properly retrieved"""
+
+        config = Config(CONF_FILE)
+
+        expected = ['askbot', 'bugzilla', 'bugzillarest', 'confluence', 'discourse', 'dockerhub', 'functest',
+                    'gerrit', 'git', 'github', 'google_hits', 'hyperkitty', 'jenkins', 'jira', 'mbox', 'meetup',
+                    'mediawiki', 'mozillaclub', 'nntp', 'phabricator', 'pipermail', 'redmine', 'remo', 'rss',
+                    'stackexchange', 'slack', 'supybot', 'telegram', 'twitter']
+        data_sources = config.get_data_sources()
+
+        self.assertEqual(len(data_sources), len(expected))
+        self.assertEqual(data_sources.sort(), expected.sort())
+
+    def test_set_param(self):
+        """Test whether a param is correctly modified"""
+
+        config = Config(CONF_FILE)
+
+        self.assertFalse(config.conf['twitter']['collect'])
+        config.set_param("twitter", "collect", "true")
+        self.assertTrue(config.conf['twitter']['collect'])
+
+    def test_set_param_not_found(self):
+        """Test whether an error is logged if a param does not exist"""
+
+        config = Config(CONF_FILE)
+
+        with self.assertLogs(logger, level='ERROR') as cm:
+            config.set_param("twitter", "acme", "true")
+            self.assertEqual(cm.output[-1], 'ERROR:sirmordred.config:Config section twitter and param acme not exists')
+
+
+if __name__ == "__main__":
+    # logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(message)s')
+    unittest.main(warnings='ignore')

--- a/tests/test_studies.cfg
+++ b/tests/test_studies.cfg
@@ -1,0 +1,109 @@
+#
+# Test config with only git and github activated
+#
+
+
+# Config values format
+#
+# List: [val1, val2 ...]
+# Int: int_value
+# Int as string: "Int"
+# List as string: "[val1, val2 ...]"
+# String: string_value
+# None: None, none
+# Boolean: true, True, False, false
+
+[general]
+short_name = Grimoire
+update = false
+min_update_delay = 10
+debug = true
+# /var/log/sigmordred/
+logs_dir = logs
+# Number of items per bulk request to Elasticsearch
+bulk_size = 100
+# Number of items to get from Elasticsearch when scrolling
+scroll_size = 100
+
+[projects]
+projects_file = test-projects.json
+
+[es_collection]
+url = http://bitergia:bitergia@localhost:9200
+# url = http://localhost:9200
+
+[es_enrichment]
+url = http://bitergia:bitergia@localhost:9200
+# url = http://localhost:9200
+autorefresh = false
+
+[sortinghat]
+host = 127.0.0.1
+user = root
+password =
+database = test_sh
+load_orgs = true
+orgs_file = data/orgs_sortinghat.json
+identities_api_token = 'xxxx'
+identities_file = [data/perceval_identities_sortinghat.json]
+affiliate = true
+# commonly: Unknown
+unaffiliated_group = Unknown
+autoprofile = [customer,git,github]
+matching = [email]
+sleep_for = 120
+# sleep_for = 1800
+bots_names = [Beloved Bot]
+
+[panels]
+kibiter_time_from= "now-30y"
+kibiter_default_index= "git"
+
+[phases]
+collection = true
+identities = true
+enrichment = true
+panels = true
+
+[git]
+raw_index = git_test-raw
+enriched_index = git_test
+studies = [enrich_demography:git, enrich_areas_of_code:git, enrich_onion:git]
+
+[enrich_demography:git]
+no_incremental = true   # default: false
+
+[enrich_areas_of_code:git]
+in_index = ???          # default: git-raw
+out_index = ???         # default: git_aoc-enriched
+sort_on_field = ???     # default: metadata__timestamp
+no_incremental = true   # default: false
+
+[enrich_onion:git]
+in_index = ???          # default: git_onion-src
+out_index = ???         # default: git_onion-enriched
+data_source = ???       # default : git
+contribs_field = ???    # default: hash)
+timeframe_field = ???     # default: grimoire_creation_date)
+sort_on_field = ???     # default: metadata__timestamp)
+no_incremental = true   # default: false
+
+[github]
+raw_index = ???
+enriched_index = ???
+api-token = ???
+no-archive = true
+sleep-for-rate = true
+studies = [enrich_onion:github]
+
+[enrich_onion:github]
+in_index_iss = ???      # default: github_issues_onion-src
+in_index_prs = ???      # default: github_prs_onion-src
+out_index_iss = ???     # default: github_issues_onion-enriched
+out_index_prs = ???     # default: github_prs_onion-enriched
+data_source_iss = ???   # default: github-issues
+data_source_prs = ???   # default: github-prs
+contribs_field = ???    # default: uuid
+timeframe_field = ???   # default: grimoire_creation_date
+sort_on_field = ???     # default: metadata__timestamp
+no_incremental = true   # default: false

--- a/tests/test_wrong.cfg
+++ b/tests/test_wrong.cfg
@@ -1,0 +1,76 @@
+#
+# Test config with only git and github activated
+#
+
+
+# Config values format
+#
+# List: [val1, val2 ...]
+# Int: int_value
+# Int as string: "Int"
+# List as string: "[val1, val2 ...]"
+# String: string_value
+# None: None, none
+# Boolean: true, True, False, false
+
+[general]
+short_name = Grimoire
+update = false
+min_update_delay = 10
+debug = true
+# /var/log/sigmordred/
+logs_dir = logs
+# Number of items per bulk request to Elasticsearch
+bulk_size = 100
+# Number of items to get from Elasticsearch when scrolling
+scroll_size = 100
+
+[projects]
+projects_file = test-projects.json
+
+[es_collection]
+url = http://bitergia:bitergia@localhost:9200
+# url = http://localhost:9200
+
+[es_enrichment]
+url = http://bitergia:bitergia@localhost:9200
+# url = http://localhost:9200
+autorefresh = false
+
+[sortinghat]
+host = 127.0.0.1
+user = root
+password =
+database = test_sh
+load_orgs = true
+orgs_file = data/orgs_sortinghat.json
+identities_api_token = 'xxxx'
+identities_file = [data/perceval_identities_sortinghat.json]
+affiliate = true
+# commonly: Unknown
+unaffiliated_group = Unknown
+autoprofile = [customer,git,github]
+matching = [email]
+sleep_for = 120
+# sleep_for = 1800
+bots_names = [Beloved Bot]
+
+[panels]
+kibiter_time_from= "now-30y"
+kibiter_default_index= "git"
+
+[phases]
+collection = true
+identities = true
+enrichment = true
+panels = true
+
+[*git]
+raw_index = git_test-raw
+enriched_index = git_test
+studies = []
+
+[fake_section]
+raw_index = fake_test-raw
+enriched_index = fake_test
+


### PR DESCRIPTION
This code allows to include extra information in a backend section name, thus enabling the collection of different data for the same backend within the same cfg. This is the case for backends with multiple categories (e.g., GitHub).