### PR TITLE
[task_panels] Do not import panels that don't have the release field

### DIFF
--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -235,8 +235,7 @@ class TaskPanels(Task):
         try:
             import_dashboard(es_enrich, panel_file, data_sources=data_sources, strict=strict)
         except ValueError:
-            logger.error("%s does not include release field. Overwritten it always.", panel_file)
-            import_dashboard(es_enrich, panel_file, data_sources=data_sources, strict=False)
+            logger.error("%s does not include release field. Not loading the panel.", panel_file)
         except RuntimeError:
             logger.error("Can not load the panel %s", panel_file)
 


### PR DESCRIPTION
If a panel does not have the release version, don't include it because
we can not detect if it is a newer version from the current one. Panels
without a release field are not supported in mordred anymore.