### PR TITLE
Load repos for a tagged backend sections

### DIFF
--- a/sirmordred/sirmordred.py
+++ b/sirmordred/sirmordred.py
@@ -146,7 +146,7 @@ class SirMordred:
                 es_error = _ofuscate_server_uri(es)
 
         if not es_access:
-            logger.error('Can not connect to Elasticsearch: %s', es_error)
+            logger.error('Cannot connect to Elasticsearch: %s', es_error)
 
         return es_access
 

--- a/sirmordred/task_projects.py
+++ b/sirmordred/task_projects.py
@@ -72,18 +72,17 @@ class TaskProjects(Task):
     def get_repos_by_backend_section(cls, backend_section):
         """ return list with the repositories for a backend_section """
         repos = []
-        backend = Task.get_backend(backend_section)
-
         projects = TaskProjects.get_projects()
 
         for pro in projects:
-            if backend in projects[pro]:
+            if backend_section in projects[pro]:
+                backend = Task.get_backend(backend_section)
                 if (backend in Config.get_global_data_sources() and
-                    cls.GLOBAL_PROJECT in projects and pro != cls.GLOBAL_PROJECT):
+                        cls.GLOBAL_PROJECT in projects and pro != cls.GLOBAL_PROJECT):
                     logger.debug("Skip global data source %s for project %s",
                                  backend, pro)
                 else:
-                    repos += projects[pro][backend]
+                    repos += projects[pro][backend_section]
 
         logger.debug("List of repos for %s: %s", backend_section, repos)
 

--- a/tests/data/url-projects.json
+++ b/tests/data/url-projects.json
@@ -28,11 +28,17 @@
    "https://github.com/VizGrimoire/GrimoireLib --filters-raw-prefix data.files.file:grimoirelib_alch data.files.file:README.md",
    "https://github.com/MetricsGrimoire/CMetrics"
   ],
+  "gitlab": [
+   "https://gitlab.com/inkscape/inkscape-web"
+  ],
   "github": [
    "https://github.com/grimoirelab/perceval"
   ],
+  "github:pull": [
+   "https://github.com/grimoirelab/perceval"
+  ],
   "google_hits": [
-   ""
+   "bitergia grimoirelab"
   ],
   "hyperkitty": [
    "https://lists.mailman3.org/archives/list/mailman-users@mailman3.org"
@@ -42,6 +48,15 @@
   ],
   "jira": [
    "https://jira.opnfv.org"
+  ],
+  "mattermost": [
+   "https://chat.openshift.io 8j366ft5affy3p36987pcugaoa"
+  ],
+  "mattermost:group1": [
+   "https://chat.openshift.io 8j366ft5affy3p36987cip"
+  ],
+  "mattermost:group2": [
+   "https://chat.openshift.io 8j366ft5affy3p36987ciop"
   ],
   "mbox": [
    "metrics-grimoire ~/.perceval/mbox"
@@ -73,6 +88,9 @@
   "remo": [
    "https://reps.mozilla.org"
   ],
+  "remo:activities": [
+   "https://reps.mozilla.org"
+  ],
   "rss": [
    "https://blog.bitergia.com/feed/"
   ],
@@ -91,7 +109,7 @@
    "Mozilla_analytics"
   ],
   "twitter": [
-   ""
+   "bitergia"
   ]
  }
 }

--- a/tests/test-projects.json
+++ b/tests/test-projects.json
@@ -29,13 +29,16 @@
    "https://github.com/MetricsGrimoire/CMetrics"
   ],
   "gitlab": [
-    "https://gitlab.com/inkscape/inkscape-web"
+   "https://gitlab.com/inkscape/inkscape-web"
   ],
   "github": [
    "https://github.com/grimoirelab/perceval"
   ],
+  "github:pull": [
+   "https://github.com/grimoirelab/perceval"
+  ],
   "google_hits": [
-   ""
+   "bitergia grimoirelab"
   ],
   "hyperkitty": [
    "https://lists.mailman3.org/archives/list/mailman-users@mailman3.org"
@@ -45,6 +48,15 @@
   ],
   "jira": [
    "https://jira.opnfv.org"
+  ],
+  "mattermost": [
+   "https://chat.openshift.io 8j366ft5affy3p36987pcugaoa"
+  ],
+  "mattermost:group1": [
+   "https://chat.openshift.io 8j366ft5affy3p36987cip"
+  ],
+  "mattermost:group2": [
+   "https://chat.openshift.io 8j366ft5affy3p36987ciop"
   ],
   "mbox": [
    "metrics-grimoire ~/.perceval/mbox"
@@ -76,6 +88,9 @@
   "remo": [
    "https://reps.mozilla.org"
   ],
+  "remo:activities": [
+   "https://reps.mozilla.org"
+  ],
   "rss": [
    "https://blog.bitergia.com/feed/"
   ],
@@ -94,7 +109,7 @@
    "Mozilla_analytics"
   ],
   "twitter": [
-   ""
+   "bitergia"
   ]
  }
 }

--- a/tests/test.cfg
+++ b/tests/test.cfg
@@ -163,6 +163,21 @@ raw_index = jira_test-raw
 enriched_index = jira_test
 project = PUP
 
+[mattermost]
+raw_index = mattermost_test
+enriched_index = mattermost_test_enriched
+api-token = xxx
+
+[mattermost:group1]
+raw_index = mattermost_test_group1
+enriched_index = mattermost_test_enriched_group1
+api-token = xxx
+
+[mattermost:group2]
+raw_index = mattermost_test_group2
+enriched_index = mattermost_test_enriched_group2
+api-token = zzz
+
 [mbox]
 raw_index = mbox_test-raw
 enriched_index = mbox_test
@@ -195,6 +210,10 @@ api-token = XXXXX
 [pipermail]
 raw_index = pipermail_test-raw
 enriched_index = pipermail_test
+
+[puppetforge]
+raw_index = puppetforge_test-raw
+enriched_index = puppetforge_test
 
 [redmine]
 raw_index = redmine_test-raw

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,7 +46,7 @@ class TestConfig(unittest.TestCase):
         self.assertIsNotNone(config.conf)
         self.assertIsNone(config.raw_conf)
         self.assertEqual(config.conf_list, [CONF_FULL])
-        self.assertEqual(len(config.conf.keys()), 43)
+        self.assertEqual(len(config.conf.keys()), 47)
 
     def test_init_studies(self):
         """Test whether studies' attributes are initializated"""
@@ -123,9 +123,9 @@ class TestConfig(unittest.TestCase):
         config = Config(CONF_FULL)
 
         expected = ['askbot', 'bugzilla', 'bugzillarest', 'confluence', 'discourse', 'dockerhub', 'functest',
-                    'gerrit', 'git', 'gitlab', 'github', 'google_hits', 'hyperkitty', 'jenkins', 'jira', 'mbox', 'meetup',
-                    'mediawiki', 'mozillaclub', 'nntp', 'phabricator', 'pipermail', 'redmine', 'remo', 'rss',
-                    'stackexchange', 'slack', 'supybot', 'telegram', 'twitter']
+                    'gerrit', 'git', 'gitlab', 'github', 'google_hits', 'groupsio', 'hyperkitty', 'jenkins', 'jira',
+                    'mbox', 'meetup', 'mediawiki', 'mozillaclub', 'nntp', 'phabricator', 'pipermail', 'puppetforge',
+                    'redmine', 'remo', 'rss', 'stackexchange', 'slack', 'supybot', 'telegram', 'twitter']
         data_sources = config.get_data_sources()
 
         self.assertEqual(len(data_sources), len(expected))

--- a/tests/test_sirmordred.py
+++ b/tests/test_sirmordred.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+
+
+import sys
+import unittest
+
+# Hack to make sure that tests import the right packages
+# due to setuptools behaviour
+sys.path.insert(0, '..')
+
+from sirmordred.config import Config
+from sirmordred.sirmordred import logger, SirMordred
+
+CONF_FILE = 'test.cfg'
+
+
+class TestTaskRawDataCollection(unittest.TestCase):
+    """Task tests"""
+
+    def setUp(self):
+        self.config = Config(CONF_FILE)
+        self.sirmordred = SirMordred(self.config)
+
+    def test_initialization(self):
+        """Test whether attributes are initializated"""
+
+        self.assertTrue(self.sirmordred.config, self.config)
+        self.assertTrue(self.sirmordred.conf, self.config.get_conf())
+        self.assertIsNotNone(self.sirmordred.grimoire_con)
+
+    def test_check_es_access(self):
+        """Test whether check_es_access properly works"""
+
+        self.sirmordred = SirMordred(self.config)
+        self.assertTrue(self.sirmordred.check_es_access())
+
+    def test_check_es_access_es_collection_error(self):
+        """Test whether an exception is thrown when es_collection is empty"""
+
+        self.sirmordred = SirMordred(self.config)
+        self.sirmordred.config.conf['es_collection']['url'] = ""
+        with self.assertLogs(logger, level='ERROR') as cm:
+            self.sirmordred.check_es_access()
+            self.assertTrue(cm.output[-1], 'ERROR:sirmordred.sirmordred:Cannot connect to Elasticsearch: ')
+
+    def test_check_es_access_es_es_enrichment_error(self):
+        """Test whether an exception is thrown when es_enrichment is empty"""
+
+        self.sirmordred = SirMordred(self.config)
+        self.sirmordred.config.conf['es_enrichment']['url'] = ""
+        with self.assertLogs(logger, level='ERROR') as cm:
+            self.sirmordred.check_es_access()
+            self.assertTrue(cm.output[-1], 'ERROR:sirmordred.sirmordred:Cannot connect to Elasticsearch: ')
+
+
+if __name__ == "__main__":
+    unittest.main(warnings='ignore')

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -60,157 +60,160 @@ class TestTasksManager(unittest.TestCase):
 
         self.assertTrue(list(self.backends.keys()), 36)
 
-        backend = list(self.backends.keys())[0]
+        backends = list(self.backends.keys())
+        backends.sort()
+
+        backend = backends[0]
         self.assertEqual(backend, 'askbot')
         self.assertEqual(self.backends[backend], ['https://ask.puppet.com'])
 
-        backend = list(self.backends.keys())[1]
+        backend = backends[1]
         self.assertEqual(backend, 'bugzilla')
         self.assertEqual(self.backends[backend], ['https://bugs.eclipse.org/bugs/'])
 
-        backend = list(self.backends.keys())[2]
+        backend = backends[2]
         self.assertEqual(backend, 'bugzillarest')
         self.assertEqual(self.backends[backend], ['https://bugzilla.mozilla.org'])
 
-        backend = list(self.backends.keys())[3]
+        backend = backends[3]
         self.assertEqual(backend, 'confluence')
         self.assertEqual(self.backends[backend], ['https://wiki.open-o.org/'])
 
-        backend = list(self.backends.keys())[4]
+        backend = backends[4]
         self.assertEqual(backend, 'discourse')
         self.assertEqual(self.backends[backend], ['https://foro.mozilla-hispano.org/'])
 
-        backend = list(self.backends.keys())[5]
+        backend = backends[5]
         self.assertEqual(backend, 'dockerhub')
         self.assertEqual(self.backends[backend], ['bitergia kibiter'])
 
-        backend = list(self.backends.keys())[6]
+        backend = backends[6]
         self.assertEqual(backend, 'functest')
         self.assertEqual(self.backends[backend], ['http://testresults.opnfv.org/test/'])
 
-        backend = list(self.backends.keys())[7]
+        backend = backends[7]
         self.assertEqual(backend, 'gerrit')
         self.assertEqual(self.backends[backend], ['review.openstack.org'])
 
-        backend = list(self.backends.keys())[8]
+        backend = backends[8]
         self.assertEqual(backend, 'git')
         self.assertEqual(self.backends[backend],
                          ["https://github.com/VizGrimoire/GrimoireLib "
                           "--filters-raw-prefix data.files.file:grimoirelib_alch data.files.file:README.md",
                           "https://github.com/MetricsGrimoire/CMetrics"])
 
-        backend = list(self.backends.keys())[9]
+        backend = backends[9]
         self.assertEqual(backend, 'github')
         self.assertEqual(self.backends[backend], ['https://github.com/grimoirelab/perceval'])
 
-        backend = list(self.backends.keys())[10]
+        backend = backends[10]
         self.assertEqual(backend, 'github:pull')
         self.assertEqual(self.backends[backend], ['https://github.com/grimoirelab/perceval'])
 
-        backend = list(self.backends.keys())[11]
+        backend = backends[11]
         self.assertEqual(backend, 'gitlab')
         self.assertEqual(self.backends[backend], ['https://gitlab.com/inkscape/inkscape-web'])
 
-        backend = list(self.backends.keys())[12]
+        backend = backends[12]
         self.assertEqual(backend, 'google_hits')
         self.assertEqual(self.backends[backend], ['bitergia grimoirelab'])
 
-        backend = list(self.backends.keys())[13]
+        backend = backends[13]
         self.assertEqual(backend, 'hyperkitty')
         self.assertEqual(self.backends[backend],
                          ['https://lists.mailman3.org/archives/list/mailman-users@mailman3.org'])
 
-        backend = list(self.backends.keys())[14]
+        backend = backends[14]
         self.assertEqual(backend, 'jenkins')
         self.assertEqual(self.backends[backend], ['https://build.opnfv.org/ci'])
 
-        backend = list(self.backends.keys())[15]
+        backend = backends[15]
         self.assertEqual(backend, 'jira')
         self.assertEqual(self.backends[backend], ['https://jira.opnfv.org'])
 
-        backend = list(self.backends.keys())[16]
+        backend = backends[16]
         self.assertEqual(backend, 'mattermost')
         self.assertEqual(self.backends[backend], ['https://chat.openshift.io 8j366ft5affy3p36987pcugaoa'])
 
-        backend = list(self.backends.keys())[17]
+        backend = backends[17]
         self.assertEqual(backend, 'mattermost:group1')
         self.assertEqual(self.backends[backend], ['https://chat.openshift.io 8j366ft5affy3p36987cip'])
 
-        backend = list(self.backends.keys())[18]
+        backend = backends[18]
         self.assertEqual(backend, 'mattermost:group2')
         self.assertEqual(self.backends[backend], ['https://chat.openshift.io 8j366ft5affy3p36987ciop'])
 
-        backend = list(self.backends.keys())[19]
+        backend = backends[19]
         self.assertEqual(backend, 'mbox')
         self.assertEqual(self.backends[backend], ['metrics-grimoire ~/.perceval/mbox'])
 
-        backend = list(self.backends.keys())[20]
+        backend = backends[20]
         self.assertEqual(backend, 'mediawiki')
         self.assertEqual(self.backends[backend], ['https://wiki.mozilla.org'])
 
-        backend = list(self.backends.keys())[21]
+        backend = backends[21]
         self.assertEqual(backend, 'meetup')
         self.assertEqual(self.backends[backend], ['South-East-Puppet-User-Group'])
 
-        backend = list(self.backends.keys())[22]
+        backend = backends[22]
         self.assertEqual(backend, 'mozillaclub')
         self.assertEqual(self.backends[backend],
                          ['https://spreadsheets.google.com/feeds/cells/'
                           '1QHl2bjBhMslyFzR5XXPzMLdzzx7oeSKTbgR5PM8qp64/ohaibtm/public/values?alt=json'])
 
-        backend = list(self.backends.keys())[23]
+        backend = backends[23]
         self.assertEqual(backend, 'nntp')
         self.assertEqual(self.backends[backend], ['news.mozilla.org mozilla.dev.project-link'])
 
-        backend = list(self.backends.keys())[24]
+        backend = backends[24]
         self.assertEqual(backend, 'phabricator')
         self.assertEqual(self.backends[backend], ['https://phabricator.wikimedia.org'])
 
-        backend = list(self.backends.keys())[25]
+        backend = backends[25]
         self.assertEqual(backend, 'pipermail')
         self.assertEqual(self.backends[backend], ['https://mail.gnome.org/archives/libart-hackers/'])
 
-        backend = list(self.backends.keys())[26]
+        backend = backends[26]
         self.assertEqual(backend, 'puppetforge')
         self.assertEqual(self.backends[backend], [''])
 
-        backend = list(self.backends.keys())[27]
+        backend = backends[27]
         self.assertEqual(backend, 'redmine')
         self.assertEqual(self.backends[backend], ['http://tracker.ceph.com/'])
 
-        backend = list(self.backends.keys())[28]
+        backend = backends[28]
         self.assertEqual(backend, 'remo')
         self.assertEqual(self.backends[backend], ['https://reps.mozilla.org'])
 
-        backend = list(self.backends.keys())[29]
+        backend = backends[29]
         self.assertEqual(backend, 'remo:activities')
         self.assertEqual(self.backends[backend], ['https://reps.mozilla.org'])
 
-        backend = list(self.backends.keys())[30]
+        backend = backends[30]
         self.assertEqual(backend, 'rss')
         self.assertEqual(self.backends[backend], ['https://blog.bitergia.com/feed/'])
 
-        backend = list(self.backends.keys())[31]
+        backend = backends[31]
         self.assertEqual(backend, 'slack')
         self.assertEqual(self.backends[backend], ['C7LSGB0AU'])
 
-        backend = list(self.backends.keys())[32]
+        backend = backends[32]
         self.assertEqual(backend, 'stackexchange')
         self.assertEqual(self.backends[backend],
                          ["https://stackoverflow.com/questions/tagged/ovirt",
                           "https://stackoverflow.com/questions/tagged/rdo",
                           "https://stackoverflow.com/questions/tagged/kibana"])
 
-        backend = list(self.backends.keys())[33]
+        backend = backends[33]
         self.assertEqual(backend, 'supybot')
         self.assertEqual(self.backends[backend],
                          ['openshift ~/.perceval/irc/percevalbot/logs/ChannelLogger/freenode/#openshift/'])
 
-        backend = list(self.backends.keys())[34]
+        backend = backends[34]
         self.assertEqual(backend, 'telegram')
         self.assertEqual(self.backends[backend], ['Mozilla_analytics'])
 
-        backend = list(self.backends.keys())[35]
+        backend = backends[35]
         self.assertEqual(backend, 'twitter')
         self.assertEqual(self.backends[backend], ['bitergia'])
 

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -52,15 +52,167 @@ class TestTasksManager(unittest.TestCase):
         self.backend_tasks = [TaskRawDataCollection, TaskEnrich]
         self.stopper = threading.Event()
 
-        # self.threads = []
-        # for backend in self.backends:
-        #     # Start new Threads and add them to the threads list to complete
-        #     t = TasksManager(self.backend_tasks, backend, self.stopper, self.config, small_delay=0)
-        #     self.threads.append(t)
-        #     t.start()
-
     def tearDown(self):
         pass
+
+    def test_repos_by_backend(self):
+        """Test whether the repos for each backend section are properly loaded"""
+
+        self.assertTrue(list(self.backends.keys()), 36)
+
+        backend = list(self.backends.keys())[0]
+        self.assertEqual(backend, 'askbot')
+        self.assertEqual(self.backends[backend], ['https://ask.puppet.com'])
+
+        backend = list(self.backends.keys())[1]
+        self.assertEqual(backend, 'bugzilla')
+        self.assertEqual(self.backends[backend], ['https://bugs.eclipse.org/bugs/'])
+
+        backend = list(self.backends.keys())[2]
+        self.assertEqual(backend, 'bugzillarest')
+        self.assertEqual(self.backends[backend], ['https://bugzilla.mozilla.org'])
+
+        backend = list(self.backends.keys())[3]
+        self.assertEqual(backend, 'confluence')
+        self.assertEqual(self.backends[backend], ['https://wiki.open-o.org/'])
+
+        backend = list(self.backends.keys())[4]
+        self.assertEqual(backend, 'discourse')
+        self.assertEqual(self.backends[backend], ['https://foro.mozilla-hispano.org/'])
+
+        backend = list(self.backends.keys())[5]
+        self.assertEqual(backend, 'dockerhub')
+        self.assertEqual(self.backends[backend], ['bitergia kibiter'])
+
+        backend = list(self.backends.keys())[6]
+        self.assertEqual(backend, 'functest')
+        self.assertEqual(self.backends[backend], ['http://testresults.opnfv.org/test/'])
+
+        backend = list(self.backends.keys())[7]
+        self.assertEqual(backend, 'gerrit')
+        self.assertEqual(self.backends[backend], ['review.openstack.org'])
+
+        backend = list(self.backends.keys())[8]
+        self.assertEqual(backend, 'git')
+        self.assertEqual(self.backends[backend],
+                         ["https://github.com/VizGrimoire/GrimoireLib "
+                          "--filters-raw-prefix data.files.file:grimoirelib_alch data.files.file:README.md",
+                          "https://github.com/MetricsGrimoire/CMetrics"])
+
+        backend = list(self.backends.keys())[9]
+        self.assertEqual(backend, 'github')
+        self.assertEqual(self.backends[backend], ['https://github.com/grimoirelab/perceval'])
+
+        backend = list(self.backends.keys())[10]
+        self.assertEqual(backend, 'github:pull')
+        self.assertEqual(self.backends[backend], ['https://github.com/grimoirelab/perceval'])
+
+        backend = list(self.backends.keys())[11]
+        self.assertEqual(backend, 'gitlab')
+        self.assertEqual(self.backends[backend], ['https://gitlab.com/inkscape/inkscape-web'])
+
+        backend = list(self.backends.keys())[12]
+        self.assertEqual(backend, 'google_hits')
+        self.assertEqual(self.backends[backend], ['bitergia grimoirelab'])
+
+        backend = list(self.backends.keys())[13]
+        self.assertEqual(backend, 'hyperkitty')
+        self.assertEqual(self.backends[backend],
+                         ['https://lists.mailman3.org/archives/list/mailman-users@mailman3.org'])
+
+        backend = list(self.backends.keys())[14]
+        self.assertEqual(backend, 'jenkins')
+        self.assertEqual(self.backends[backend], ['https://build.opnfv.org/ci'])
+
+        backend = list(self.backends.keys())[15]
+        self.assertEqual(backend, 'jira')
+        self.assertEqual(self.backends[backend], ['https://jira.opnfv.org'])
+
+        backend = list(self.backends.keys())[16]
+        self.assertEqual(backend, 'mattermost')
+        self.assertEqual(self.backends[backend], ['https://chat.openshift.io 8j366ft5affy3p36987pcugaoa'])
+
+        backend = list(self.backends.keys())[17]
+        self.assertEqual(backend, 'mattermost:group1')
+        self.assertEqual(self.backends[backend], ['https://chat.openshift.io 8j366ft5affy3p36987cip'])
+
+        backend = list(self.backends.keys())[18]
+        self.assertEqual(backend, 'mattermost:group2')
+        self.assertEqual(self.backends[backend], ['https://chat.openshift.io 8j366ft5affy3p36987ciop'])
+
+        backend = list(self.backends.keys())[19]
+        self.assertEqual(backend, 'mbox')
+        self.assertEqual(self.backends[backend], ['metrics-grimoire ~/.perceval/mbox'])
+
+        backend = list(self.backends.keys())[20]
+        self.assertEqual(backend, 'mediawiki')
+        self.assertEqual(self.backends[backend], ['https://wiki.mozilla.org'])
+
+        backend = list(self.backends.keys())[21]
+        self.assertEqual(backend, 'meetup')
+        self.assertEqual(self.backends[backend], ['South-East-Puppet-User-Group'])
+
+        backend = list(self.backends.keys())[22]
+        self.assertEqual(backend, 'mozillaclub')
+        self.assertEqual(self.backends[backend],
+                         ['https://spreadsheets.google.com/feeds/cells/'
+                          '1QHl2bjBhMslyFzR5XXPzMLdzzx7oeSKTbgR5PM8qp64/ohaibtm/public/values?alt=json'])
+
+        backend = list(self.backends.keys())[23]
+        self.assertEqual(backend, 'nntp')
+        self.assertEqual(self.backends[backend], ['news.mozilla.org mozilla.dev.project-link'])
+
+        backend = list(self.backends.keys())[24]
+        self.assertEqual(backend, 'phabricator')
+        self.assertEqual(self.backends[backend], ['https://phabricator.wikimedia.org'])
+
+        backend = list(self.backends.keys())[25]
+        self.assertEqual(backend, 'pipermail')
+        self.assertEqual(self.backends[backend], ['https://mail.gnome.org/archives/libart-hackers/'])
+
+        backend = list(self.backends.keys())[26]
+        self.assertEqual(backend, 'puppetforge')
+        self.assertEqual(self.backends[backend], [''])
+
+        backend = list(self.backends.keys())[27]
+        self.assertEqual(backend, 'redmine')
+        self.assertEqual(self.backends[backend], ['http://tracker.ceph.com/'])
+
+        backend = list(self.backends.keys())[28]
+        self.assertEqual(backend, 'remo')
+        self.assertEqual(self.backends[backend], ['https://reps.mozilla.org'])
+
+        backend = list(self.backends.keys())[29]
+        self.assertEqual(backend, 'remo:activities')
+        self.assertEqual(self.backends[backend], ['https://reps.mozilla.org'])
+
+        backend = list(self.backends.keys())[30]
+        self.assertEqual(backend, 'rss')
+        self.assertEqual(self.backends[backend], ['https://blog.bitergia.com/feed/'])
+
+        backend = list(self.backends.keys())[31]
+        self.assertEqual(backend, 'slack')
+        self.assertEqual(self.backends[backend], ['C7LSGB0AU'])
+
+        backend = list(self.backends.keys())[32]
+        self.assertEqual(backend, 'stackexchange')
+        self.assertEqual(self.backends[backend],
+                         ["https://stackoverflow.com/questions/tagged/ovirt",
+                          "https://stackoverflow.com/questions/tagged/rdo",
+                          "https://stackoverflow.com/questions/tagged/kibana"])
+
+        backend = list(self.backends.keys())[33]
+        self.assertEqual(backend, 'supybot')
+        self.assertEqual(self.backends[backend],
+                         ['openshift ~/.perceval/irc/percevalbot/logs/ChannelLogger/freenode/#openshift/'])
+
+        backend = list(self.backends.keys())[34]
+        self.assertEqual(backend, 'telegram')
+        self.assertEqual(self.backends[backend], ['Mozilla_analytics'])
+
+        backend = list(self.backends.keys())[35]
+        self.assertEqual(backend, 'twitter')
+        self.assertEqual(self.backends[backend], ['bitergia'])
 
     def test_initialization(self):
         """Test whether attributes are initializated"""

--- a/tests/test_task_projects.py
+++ b/tests/test_task_projects.py
@@ -92,6 +92,208 @@ class TestTaskProjects(unittest.TestCase):
 
         self.assertEqual(task.config, config)
 
+    def test_get_repos_by_backend_section(self):
+        """Test whether the repos of each section are properly loaded"""
+
+        config = Config(CONF_FILE)
+        task = TaskProjects(config)
+        self.assertEqual(task.execute(), None)
+
+        config.conf.keys()
+        backend_sections = list(set([sect for sect in config.conf.keys()
+                                     for backend_section in Config.get_backend_sections()
+                                     if sect and sect.startswith(backend_section)]))
+        backend_sections.sort()
+        backend = backend_sections[0]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'askbot')
+        self.assertEqual(repos, ['https://ask.puppet.com'])
+
+        backend = backend_sections[1]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'bugzilla')
+        self.assertEqual(repos, ['https://bugs.eclipse.org/bugs/'])
+
+        backend = backend_sections[2]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'bugzillarest')
+        self.assertEqual(repos, ['https://bugzilla.mozilla.org'])
+
+        backend = backend_sections[3]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'confluence')
+        self.assertEqual(repos, ['https://wiki.open-o.org/'])
+
+        backend = backend_sections[4]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'discourse')
+        self.assertEqual(repos, ['https://foro.mozilla-hispano.org/'])
+
+        backend = backend_sections[5]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'dockerhub')
+        self.assertEqual(repos, ['bitergia kibiter'])
+
+        backend = backend_sections[6]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'functest')
+        self.assertEqual(repos, ['http://testresults.opnfv.org/test/'])
+
+        backend = backend_sections[7]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'gerrit')
+        self.assertEqual(repos, ['review.openstack.org'])
+
+        backend = backend_sections[8]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'git')
+        self.assertEqual(repos,
+                         ["https://github.com/VizGrimoire/GrimoireLib "
+                          "--filters-raw-prefix data.files.file:grimoirelib_alch data.files.file:README.md",
+                          "https://github.com/MetricsGrimoire/CMetrics"])
+
+        backend = backend_sections[9]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'github')
+        self.assertEqual(repos, ['https://github.com/grimoirelab/perceval'])
+
+        backend = backend_sections[10]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'github:pull')
+        self.assertEqual(repos, ['https://github.com/grimoirelab/perceval'])
+
+        backend = backend_sections[11]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'gitlab')
+        self.assertEqual(repos, ['https://gitlab.com/inkscape/inkscape-web'])
+
+        backend = backend_sections[12]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'google_hits')
+        self.assertEqual(repos, ['bitergia grimoirelab'])
+
+        backend = backend_sections[13]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'hyperkitty')
+        self.assertEqual(repos,
+                         ['https://lists.mailman3.org/archives/list/mailman-users@mailman3.org'])
+
+        backend = backend_sections[14]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'jenkins')
+        self.assertEqual(repos, ['https://build.opnfv.org/ci'])
+
+        backend = backend_sections[15]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'jira')
+        self.assertEqual(repos, ['https://jira.opnfv.org'])
+
+        backend = backend_sections[16]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'mattermost')
+        self.assertEqual(repos, ['https://chat.openshift.io 8j366ft5affy3p36987pcugaoa'])
+
+        backend = backend_sections[17]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'mattermost:group1')
+        self.assertEqual(repos, ['https://chat.openshift.io 8j366ft5affy3p36987cip'])
+
+        backend = backend_sections[18]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'mattermost:group2')
+        self.assertEqual(repos, ['https://chat.openshift.io 8j366ft5affy3p36987ciop'])
+
+        backend = backend_sections[19]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'mbox')
+        self.assertEqual(repos, ['metrics-grimoire ~/.perceval/mbox'])
+
+        backend = backend_sections[20]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'mediawiki')
+        self.assertEqual(repos, ['https://wiki.mozilla.org'])
+
+        backend = backend_sections[21]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'meetup')
+        self.assertEqual(repos, ['South-East-Puppet-User-Group'])
+
+        backend = backend_sections[22]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'mozillaclub')
+        self.assertEqual(repos,
+                         ['https://spreadsheets.google.com/feeds/cells/'
+                          '1QHl2bjBhMslyFzR5XXPzMLdzzx7oeSKTbgR5PM8qp64/ohaibtm/public/values?alt=json'])
+
+        backend = backend_sections[23]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'nntp')
+        self.assertEqual(repos, ['news.mozilla.org mozilla.dev.project-link'])
+
+        backend = backend_sections[24]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'phabricator')
+        self.assertEqual(repos, ['https://phabricator.wikimedia.org'])
+
+        backend = backend_sections[25]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'pipermail')
+        self.assertEqual(repos, ['https://mail.gnome.org/archives/libart-hackers/'])
+
+        backend = backend_sections[26]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'puppetforge')
+        self.assertEqual(repos, [''])
+
+        backend = backend_sections[27]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'redmine')
+        self.assertEqual(repos, ['http://tracker.ceph.com/'])
+
+        backend = backend_sections[28]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'remo')
+        self.assertEqual(repos, ['https://reps.mozilla.org'])
+
+        backend = backend_sections[29]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'remo:activities')
+        self.assertEqual(repos, ['https://reps.mozilla.org'])
+
+        backend = backend_sections[30]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'rss')
+        self.assertEqual(repos, ['https://blog.bitergia.com/feed/'])
+
+        backend = backend_sections[31]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'slack')
+        self.assertEqual(repos, ['C7LSGB0AU'])
+
+        backend = backend_sections[32]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'stackexchange')
+        self.assertEqual(repos,
+                         ["https://stackoverflow.com/questions/tagged/ovirt",
+                          "https://stackoverflow.com/questions/tagged/rdo",
+                          "https://stackoverflow.com/questions/tagged/kibana"])
+
+        backend = backend_sections[33]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'supybot')
+        self.assertEqual(repos,
+                         ['openshift ~/.perceval/irc/percevalbot/logs/ChannelLogger/freenode/#openshift/'])
+
+        backend = backend_sections[34]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'telegram')
+        self.assertEqual(repos, ['Mozilla_analytics'])
+
+        backend = backend_sections[35]
+        repos = task.get_repos_by_backend_section(backend)
+        self.assertEqual(backend, 'twitter')
+        self.assertEqual(repos, ['bitergia'])
+
     def test_run(self):
         """Test whether the Task could be run"""
         config = Config(CONF_FILE)


### PR DESCRIPTION
This code enables to load repos for a tagged backend sections. In the cfg, you can define multiple sections for the same backend using tags (e.g., github -> [github:issues], [github:pulls]), in the projects.json every entry has to be linked to a corresponding tagged section (e.g., "github:issues": [list of repos], "github:pulls": [list of repos].