### PR TITLE
[utils] Add micro-mordred

### DIFF
--- a/utils/menu.yaml
+++ b/utils/menu.yaml
@@ -1,0 +1,278 @@
+---
+- name: Git
+  source: git
+  icon: default.png
+  index-patterns:
+  - panels/json/git-index-pattern.json
+  - panels/json/git_areas_of_code-index-pattern.json
+  - panels/json/all_onion-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/git.json
+  - name: Attraction/Retention
+    panel: panels/json/git_demographics.json
+  - name: Areas of code
+    panel: panels/json/git_areas_of_code.json
+- name: Gerrit
+  source: gerrit
+  icon: default.png
+  index-patterns:
+  - panels/json/gerrit-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/gerrit.json
+  - name: Backlog
+    panel: panels/json/gerrit_backlog.json
+  - name: Timing
+    panel: panels/json/gerrit_timing.json
+- name: GitHub PRs
+  source: github
+  icon: default.png
+  index-patterns:
+  - panels/json/github_issues-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/github_pull_requests.json
+  - name: Backlog
+    panel: panels/json/github_pull_requests_backlog.json
+  - name: Timing
+    panel: panels/json/github_pull_requests_timing.json
+- name: GitHub Issues
+  source: github
+  icon: default.png
+  index-patterns:
+  - panels/json/github_issues-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/github_issues.json
+  - name: Backlog
+    panel: panels/json/github_issues_backlog.json
+  - name: Timing
+    panel: panels/json/github_issues_timing.json
+- name: Phabricator
+  source: phabricator
+  icon: default.png
+  index-patterns:
+  - panels/json/maniphest-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/maniphest.json
+  - name: Backlog
+    panel: panels/json/maniphest_backlog.json
+  - name: Timing
+    panel: panels/json/maniphest_timing.json
+- name: Redmine
+  source: redmine
+  icon: default.png
+  index-patterns:
+  - panels/json/redmine-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/redmine.json
+  - name: Backlog
+    panel: panels/json/redmine_backlog.json
+  - name: Timing
+    panel: panels/json/redmine_timing.json
+- name: Jira
+  source: jira
+  icon: default.png
+  index-patterns:
+  - panels/json/jira-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/jira.json
+  - name: Backlog
+    panel: panels/json/jira_backlog.json
+  - name: Timing
+    panel: panels/json/jira_timing.json
+- name: Bugzilla
+  source: bugzilla
+  icon: default.png
+  index-patterns:
+  - panels/json/bugzilla-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/bugzilla.json
+  - name: Backlog
+    panel: panels/json/bugzilla_backlog.json
+  - name: Timing
+    panel: panels/json/bugzilla_timing.json
+- name: Bugzilla
+  source: bugzillarest
+  icon: default.png
+  index-patterns:
+  - panels/json/bugzilla-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/bugzilla.json
+  - name: Backlog
+    panel: panels/json/bugzilla_backlog.json
+  - name: Timing
+    panel: panels/json/bugzilla_timing.json
+- name: Confluence
+  source: confluence
+  icon: default.png
+  index-patterns:
+  - panels/json/confluence-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/confluence.json
+- name: MediaWiki
+  source: mediawiki
+  icon: default.png
+  index-patterns:
+  - panels/json/mediawiki-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/mediawiki.json
+- name: Mailing Lists
+  source: mbox
+  icon: default.png
+  index-patterns:
+  - panels/json/mbox-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/mailinglists.json
+- name: Mailing Lists
+  source: pipermail
+  icon: default.png
+  index-patterns:
+  - panels/json/mbox-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/mailinglists.json
+- name: Discourse
+  source: discourse
+  icon: default.png
+  index-patterns:
+  - panels/json/discourse-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/discourse.json
+- name: Blogs (RSS)
+  source: rss
+  icon: default.png
+  index-patterns:
+  - panels/json/rss-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/rss.json
+- name: IRC
+  source: supybot
+  icon: default.png
+  index-patterns:
+  - panels/json/irc-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/irc.json
+- name: Slack
+  source: slack
+  icon: default.png
+  index-patterns:
+  - panels/json/slack-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/slack.json
+- name: Telegram
+  source: telegram
+  icon: default.png
+  index-patterns:
+  - panels/json/telegram-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/telegram.json
+- name: Twitter
+  source: twitter
+  icon: default.png
+  index-patterns:
+  - panels/json/twitter-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/twitter.json
+- name: Askbot Q&A
+  source: askbot
+  icon: default.png
+  index-patterns:
+  - panels/json/askbot-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/askbot.json
+- name: StackOverflow
+  source: stackexchange
+  icon: default.png
+  index-patterns:
+  - panels/json/stackoverflow-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/stackoverflow.json
+- name: Jenkins
+  source: jenkins
+  icon: default.png
+  index-patterns:
+  - panels/json/jenkins-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/jenkins.json
+- name: Mozilla Club
+  source: mozillaclub
+  icon: default.png
+  index-patterns:
+  - panels/json/mozillaclub-index-pattern.json
+  menu:
+  - name: Events
+    panel: panels/json/mozilla_club.json
+- name: Mozilla Reps
+  source: remo
+  icon: default.png
+  index-patterns:
+  - panels/json/remo-activities-index-pattern.json
+  - panels/json/remo-activities_metadata__timestamp-index-pattern.json
+  - panels/json/remo-events-index-pattern.json
+  - panels/json/remo-events_metadata__timestamp-index-pattern.json
+  menu:
+  - name: Events
+    panel: panels/json/reps_events.json
+  - name: Activities
+    panel: panels/json/reps_activities.json
+- name: Meetup
+  source: meetup
+  icon: default.png
+  index-patterns:
+  - panels/json/meetup-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/meetup.json
+  - name: Locations
+    panel: panels/json/meetup_locations.json
+- name: Google Hits
+  source: google_hits
+  icon: default.png
+  index-patterns:
+  - panels/json/google-hits-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/google_hits.json
+- name: DockerHub
+  source: dockerhub
+  icon: default.png
+  index-patterns:
+  - panels/json/dockerhub-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/dockerhub.json
+- name: Apache
+  source: apache
+  icon: default.png
+  index-patterns:
+  - panels/json/apache-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/apache.json
+- name: Testing
+  source: functest
+  icon: default.png
+  index-patterns:
+  - panels/json/functest-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/testing_all.json

--- a/utils/micro.py
+++ b/utils/micro.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#   Valerio Cosentino <valcos@bitergia.com>
+#
+
+import argparse
+import logging
+import sys
+
+from sirmordred.config import Config
+from sirmordred.task_collection import TaskRawDataCollection, TaskRawDataArthurCollection
+from sirmordred.task_identities import TaskIdentitiesMerge
+from sirmordred.task_enrich import TaskEnrich
+from sirmordred.task_panels import TaskPanels, TaskPanelsMenu, TaskPanelsAliases
+from sirmordred.task_projects import TaskProjects
+
+DEBUG_LOG_FORMAT = "[%(asctime)s - %(name)s - %(levelname)s] - %(message)s"
+logging.basicConfig(level=logging.DEBUG, format=DEBUG_LOG_FORMAT)
+
+
+def micro_mordred(cfg_path, backend_sections, raw, arthur, identities, enrich, panels):
+    """Execute the raw and/or the enrich phases of a given backend section defined in a Mordred configuration file.
+
+    :param cfg_path: the path of a Mordred configuration file
+    :param backend_sections: the backend sections where the raw and/or enrich phases will be executed
+    :param raw: if true, it activates the collection of raw data
+    :param arthur: if true, it enables Arthur to collect the raw data
+    :param identities: if true, it activates the identities merge in SortingHat
+    :param enrich: if true, it activates the collection of enrich data
+    :param panels: if true, it activates the upload of panels
+    """
+
+    config = Config(cfg_path)
+
+    if raw:
+        for backend in backend_sections:
+            get_raw(config, backend, arthur)
+
+    if identities:
+        get_identities(config)
+
+    if enrich:
+        for backend in backend_sections:
+            get_enrich(config, backend)
+
+    if panels:
+        for backend in backend_sections:
+            task = TaskPanelsAliases(config)
+            task.backend_section = backend
+            task.execute()
+
+        get_panels(config)
+
+
+def get_raw(config, backend_section, arthur):
+    """Execute the raw phase for a given backend section, optionally using Arthur
+
+    :param config: a Mordred config object
+    :param backend_section: the backend section where the raw phase is executed
+    :param arthur: if true, it enables Arthur to collect the raw data
+    """
+
+    if arthur:
+        task = TaskRawDataArthurCollection(config, backend_section=backend_section)
+    else:
+        task = TaskRawDataCollection(config, backend_section=backend_section)
+
+    TaskProjects(config).execute()
+    task.execute()
+    logging.info("Loading raw data finished!")
+
+
+def get_identities(config):
+    """Execute the merge identities phase
+
+    :param config: a Mordred config object
+    """
+
+    TaskProjects(config).execute()
+    task = TaskIdentitiesMerge(config)
+    task.execute()
+    logging.info("Merging identities finished!")
+
+
+def get_enrich(config, backend_section):
+    """Execute the enrich phase for a given backend section
+
+    :param config: a Mordred config object
+    :param backend_section: the backend section where the enrich phase is executed
+    """
+
+    TaskProjects(config).execute()
+    task = TaskEnrich(config, backend_section=backend_section)
+    task.execute()
+    logging.info("Loading enriched data finished!")
+
+
+def get_panels(config):
+    """Execute the panels phase
+
+    :param config: a Mordred config object
+    """
+
+    task = TaskPanels(config)
+    task.execute()
+
+    task = TaskPanelsMenu(config)
+    task.execute()
+
+    logging.info("Panels creation finished!")
+
+
+def config_logging(debug):
+    """Config logging level output output"""
+
+    if debug:
+        logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(message)s')
+        logging.debug("Debug mode activated")
+    else:
+        logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
+
+
+def get_params_parser():
+    """Parse command line arguments"""
+
+    parser = argparse.ArgumentParser(add_help=False)
+
+    parser.add_argument('-g', '--debug', dest='debug',
+                        action='store_true',
+                        help=argparse.SUPPRESS)
+    parser.add_argument("--arthur", action='store_true', dest='arthur',
+                        help="Enable arthur to collect raw data")
+    parser.add_argument("--raw", action='store_true', dest='raw',
+                        help="Activate raw task")
+    parser.add_argument("--enrich", action='store_true', dest='enrich',
+                        help="Activate enrich task")
+    parser.add_argument("--identities", action='store_true', dest='identities',
+                        help="Activate merge identities task")
+    parser.add_argument("--panels", action='store_true', dest='panels',
+                        help="Activate panels task")
+
+    parser.add_argument("--cfg", dest='cfg_path',
+                        help="Configuration file path")
+    parser.add_argument("--backends", dest='backend_sections', default=[],
+                        nargs='*', help="Backend sections to execute")
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
+    return parser
+
+
+def get_params():
+    """Get params to execute the micro-mordred"""
+
+    parser = get_params_parser()
+    args = parser.parse_args()
+
+    if not args.raw and not args.enrich and not args.identities and not args.panels:
+        print("No tasks enabled")
+        sys.exit(1)
+
+    return args
+
+
+if __name__ == '__main__':
+
+    args = get_params()
+    config_logging(args.debug)
+
+    micro_mordred(args.cfg_path, args.backend_sections,
+                  args.raw, args.arthur,
+                  args.identities,
+                  args.enrich,
+                  args.panels)

--- a/utils/projects.json
+++ b/utils/projects.json
@@ -1,0 +1,13 @@
+{
+    "grimoire": {
+        "git": [
+            "https://github.com/chaoss/grimoirelab-perceval"
+        ],
+        "*github:issue": [
+            "https://github.com/chaoss/grimoirelab-perceval"
+        ],
+        "*github:pull": [
+            "https://github.com/chaoss/grimoirelab-perceval"
+        ]
+    }
+}

--- a/utils/setup.cfg
+++ b/utils/setup.cfg
@@ -1,0 +1,116 @@
+#
+# Test config with only git and github activated
+#
+
+
+# Config values format
+#
+# List: [val1, val2 ...]
+# Int: int_value
+# Int as string: "Int"
+# List as string: "[val1, val2 ...]"
+# String: string_value
+# None: None, none
+# Boolean: true, True, False, false
+
+[general]
+short_name = Grimoire
+update = false
+min_update_delay = 10
+debug = true
+# /var/log/mordred/
+logs_dir = logs
+# Number of items per bulk request to Elasticsearch
+bulk_size = 100
+# Number of items to get from Elasticsearch when scrolling
+scroll_size = 100
+
+[projects]
+projects_file = ./projects.json
+
+[es_collection]
+arthur = true
+arthur_url = http://127.0.0.1:8080
+redis_url = redis://localhost/8
+url = http://localhost:9200
+
+[es_enrichment]
+url = http://localhost:9200
+
+[sortinghat]
+host = 127.0.0.1
+user = root
+password =
+database = test_sh
+load_orgs = true
+orgs_file = data/orgs_sortinghat.json
+identities_api_token = 'xxxx'
+identities_file = [data/perceval_identities_sortinghat.json]
+affiliate = true
+# commonly: Unknown
+unaffiliated_group = Unknown
+autoprofile = [customer,git,github]
+matching = [email]
+sleep_for = 120
+# sleep_for = 1800
+bots_names = [Beloved Bot]
+
+[panels]
+kibiter_time_from= "now-30y"
+kibiter_default_index= "git"
+community = true
+
+[phases]
+collection = true
+identities = true
+enrichment = true
+panels = true
+
+[git]
+raw_index = git_chaoss_180804
+enriched_index = git_chaoss_180804_enriched_180804
+latest-items = true
+category = commit
+studies = [enrich_demography:git, enrich_areas_of_code:git, enrich_onion:git]
+
+[github:issue]
+raw_index = github_issues_chaoss_180804
+enriched_index = github_issues_chaoss_180804_enriched_180804
+api-token = xxxx
+sleep-for-rate = true
+no-archive = true
+category = issue
+sleep-time = 300
+
+[github:pull]
+raw_index = github_pulls_chaoss_180804
+enriched_index = github_pulls_chaoss_180804_enriched_180804
+api-token = xxxx
+sleep-for-rate = true
+no-archive = true
+category = pull_request
+sleep-time = 300
+studies = [enrich_onion:github]
+
+[enrich_demography:git]
+#no_incremental = true
+
+[enrich_areas_of_code:git]
+#no_incremental = true
+in_index = git_commit_chaoss_180801
+out_index = git-aoc_chaoss_enriched_180801
+
+[enrich_onion:git]
+in_index = git_commit_chaoss_180801_enriched_180801
+out_index = git-onion_chaoss_enriched_180801
+contribs_field = hash
+no_incremental = false
+
+[enrich_onion:github]
+#no_incremental = true
+in_index_iss = github_issues_chaoss_180804_enriched_180804
+in_index_prs = github_pulls_chaoss_180804_enriched_180804
+out_index_iss = github_issues_onion-enriched_180804
+out_index_prs = github_prs_onion-enriched_180804
+data_source_iss = github-issues
+data_source_prs = github-prs


### PR DESCRIPTION
This code proposes a tiny version of mordred to execute just once raw, merge identities, enrich, panels tasks of mordred on a given set of backends (declared in a cfg file passed as input). The micro-mordred overcomes the current limitations of the p2o script in ELK, which is not able to execute multiple studies for the input backend and requires constant changes to align its logic with the ELK one. The micro-mordred isn't supposed to require constant changes, since there is not gap between its logic and the mordred one.
    
In order to execute the micro-mordred on git and github, an example of the command is shown below:
`micro --raw --identities --enrich --panels --cfg ./setup.cfg --backends git github:issue github:pull`.