### PR TITLE
[config] Add `enrich_pull_requests` to the tuple of studies

### DIFF
--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -594,7 +594,8 @@ class Config():
     def get_study_sections(cls):
         # a study name could include and extra ":<param>"
         # to have several backend entries with different configs
-        studies = ("enrich_demography", "enrich_areas_of_code", "enrich_onion", "kafka_kip")
+        studies = ("enrich_demography", "enrich_areas_of_code", "enrich_onion", "kafka_kip",
+                   "enrich_pull_requests")
 
         return studies
 


### PR DESCRIPTION
This code adds `enrich_pull_requests` as one of the studies that can
be run, in the studies tuple in the `get_study_section` method.

This code helps add the functionality to to enrich pull requests only
index with additional fields. PRs related to this code are:
- https://github.com/chaoss/grimoirelab-sirmordred/pull/190
- https://github.com/chaoss/grimoirelab-elk/pull/419