### PR TITLE
[tests] Add example of enrich_pull_requests study in test_studies.cfg

### DIFF
--- a/tests/test_studies.cfg
+++ b/tests/test_studies.cfg
@@ -104,6 +104,7 @@ api-token = ???         # default: none
 sleep-for-rate = true   # default: false
 no-archive = true       # default: false
 category = pull_request # default: issue
+studies = [enrich_pull_requests]
 
 [enrich_onion:github]
 in_index_iss = ???      # default: github_issues_onion-src
@@ -116,3 +117,6 @@ contribs_field = ???    # default: uuid
 timeframe_field = ???   # default: grimoire_creation_date
 sort_on_field = ???     # default: metadata__timestamp
 no_incremental = true   # default: false
+
+[enrich_pull_requests]
+raw_issues_index = ???	# default: github_issues_raw. Name of the raw issues index used for github issues data source


### PR DESCRIPTION
Add example of how to use the enrich_pull_requests study to the
test_studies.cfg file.
The enrich_pull_requests study should be done under the github:pull_requests
category and takes in an argument `raw_issues_index` which is the name
if the github issues raw index.