### PR TITLE
[config] Add time interval for autorefresh

### DIFF
--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -278,6 +278,12 @@ class Config():
                     "type": bool,
                     "description": "Execute the autorefresh of identities"
                 },
+                "autorefresh_interval": {
+                    "optional": True,
+                    "default": 2,
+                    "type": int,
+                    "description": "Set time interval (days) for autorefresh identities"
+                },
                 "user": {
                     "optional": True,
                     "default": None,


### PR DESCRIPTION
This code extends the cfg with the new parameter `autorefresh_interval` in section `es_enrichment`. When Mordred is launched, the `last_refresh_interval` is set to the current time minus the number of days defined in `autorefresh_interval` (by default 2). Thus all SH identities modified before that time are used to refresh the author data. In the other execution `last_refresh_interval` is set to the current time.