### PR TITLE
Fix typos for Kibana 6.x panels

### DIFF
--- a/menu.yaml
+++ b/menu.yaml
@@ -223,7 +223,7 @@
   source: mozillaclub
   icon: default.png
   index-patterns:
-  - panels/json/mozillaclub-index-pattern.json
+  - panels/json/mozilla_club-index-pattern.json
   menu:
   - name: Events
     panel: panels/json/mozilla_club.json
@@ -257,7 +257,7 @@
   - panels/json/google-hits-index-pattern.json
   menu:
   - name: Overview
-    panel: panels/json/google_hits.json
+    panel: panels/json/google-hits.json
 - name: DockerHub
   source: dockerhub
   icon: default.png

--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -45,9 +45,9 @@ ONION_PANEL_OVERALL = 'panels/json/onion_overall.json'
 ONION_PANEL_PROJECTS = 'panels/json/onion_projects.json'
 ONION_PANEL_ORGS = 'panels/json/onion_organizations.json'
 
-ONION_PANEL_OVERALL_IP = 'panels/json/onion_overall-index-pattern.json'
-ONION_PANEL_PROJECTS_IP = 'panels/json/onion_projects-index-pattern.json'
-ONION_PANEL_ORGS_IP = 'panels/json/onion_organizations-index-pattern.json'
+ONION_PANEL_OVERALL_IP = 'panels/json/all_onion-index-pattern.json'
+ONION_PANEL_PROJECTS_IP = 'panels/json/all_onion-index-pattern.json'
+ONION_PANEL_ORGS_IP = 'panels/json/all_onion-index-pattern.json'
 
 COMMUNITY_MENU = {
     'name': 'Community',

--- a/utils/menu.yaml
+++ b/utils/menu.yaml
@@ -217,7 +217,7 @@
   source: mozillaclub
   icon: default.png
   index-patterns:
-  - panels/json/mozillaclub-index-pattern.json
+  - panels/json/mozilla_club-index-pattern.json
   menu:
   - name: Events
     panel: panels/json/mozilla_club.json
@@ -251,7 +251,7 @@
   - panels/json/google-hits-index-pattern.json
   menu:
   - name: Overview
-    panel: panels/json/google_hits.json
+    panel: panels/json/google-hits.json
 - name: DockerHub
   source: dockerhub
   icon: default.png


### PR DESCRIPTION
Some typos were found related to the migration to Kibana 6.x panels.
This patch fixes them.