### PR TITLE
[menu] Fix remo-activities index-patterns entry

### DIFF
--- a/menu.yaml
+++ b/menu.yaml
@@ -232,7 +232,6 @@
   icon: default.png
   index-patterns:
   - panels/json/remo-activities-index-pattern.json
-  - panels/json/remo-activities_metadata__timestamp-index-pattern.json
   - panels/json/remo-events-index-pattern.json
   - panels/json/remo-events_metadata__timestamp-index-pattern.json
   menu:


### PR DESCRIPTION
remo-activities panel uses only one index pattern. Two
were configured, probably due to a copy/paste from
remo-events panel, which follows a different approach.