### PR TITLE
[menu] Add index pattern for remo-activities

### DIFF
--- a/menu.yaml
+++ b/menu.yaml
@@ -232,6 +232,7 @@
   icon: default.png
   index-patterns:
   - panels/json/remo-activities-index-pattern.json
+  - panels/json/remo-activities_metadata__timestamp-index-pattern.json
   - panels/json/remo-events-index-pattern.json
   - panels/json/remo-events_metadata__timestamp-index-pattern.json
   menu:


### PR DESCRIPTION
This index pattern was removed by previous commit
b1a75ba71b5ce18f9eb020f37c2bade6a8889567
because that index pattern did not exists in sigils repo.

Nevertheless, that index pattern is needed by data status
panel to work, so it has been added to sigils. This commit
adds the corresponding entry again to `menu.yaml` file.