### PR TITLE
[utils] Fix setup.cfg for micro-mordred

### DIFF
--- a/utils/setup.cfg
+++ b/utils/setup.cfg
@@ -97,12 +97,12 @@ studies = [enrich_onion:github]
 
 [enrich_areas_of_code:git]
 #no_incremental = true
-in_index = git_commit_chaoss_180801
-out_index = git-aoc_chaoss_enriched_180801
+in_index = git_chaoss_180804
+out_index = git-aoc_chaoss_enriched_180804
 
 [enrich_onion:git]
-in_index = git_commit_chaoss_180801_enriched_180801
-out_index = git-onion_chaoss_enriched_180801
+in_index = git_chaoss_180804_enriched_180804
+out_index = git-onion_chaoss_enriched_180804
 contribs_field = hash
 no_incremental = false
 


### PR DESCRIPTION
This code fixes the indexes declared in the git studies, which were pointing to indexes not created by micro-mordred.