### PR TITLE
[collection] Add support for mediawiki tag

### DIFF
--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -230,6 +230,8 @@ class TaskRawDataArthurCollection(Task):
             # The same repo could appear in git and github data sources
             # Two tasks in arthur can not have the same tag
             tag = repo + "_" + self.backend_section
+        if self.backend_section in ["mediawiki"]:
+            tag = repo.split()[0]
 
         return tag
 


### PR DESCRIPTION
Mediawiki supports two params now within the repo string,
this change adds support to extract the right one as tag.