### PR TITLE
[panels] Modify googlehits data source name

### DIFF
--- a/menu.yaml
+++ b/menu.yaml
@@ -253,7 +253,7 @@
   - name: Locations
     panel: panels/json/meetup_locations.json
 - name: Google Hits
-  source: google_hits
+  source: googlehits
   icon: default.png
   index-patterns:
   - panels/json/google-hits-index-pattern.json

--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -252,6 +252,9 @@ class TaskPanels(Task):
             # the dashboard for mbox and pipermail and hyperkitty are the same
             data_sources = list(data_sources)
             data_sources.append('mbox')
+        if data_sources and 'google_hits' in data_sources:
+            data_sources = list(data_sources)
+            data_sources.append('googlehits')
         if data_sources and 'stackexchange' in data_sources:
             # stackexchange is called stackoverflow in panels
             data_sources = list(data_sources)


### PR DESCRIPTION
This PR modifies `google hits` names (data source and backend name) to avoid losing widgets in the overview visualization.