### PR TITLE
Fix missing vis overview status

### DIFF
--- a/menu.yaml
+++ b/menu.yaml
@@ -126,7 +126,31 @@
   - name: Overview
     panel: panels/json/mediawiki.json
 - name: Mailing Lists
+  source: groupsio
+  icon: default.png
+  index-patterns:
+  - panels/json/mbox-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/mailinglists.json
+- name: Mailing Lists
+  source: hyperkitty
+  icon: default.png
+  index-patterns:
+  - panels/json/mbox-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/mailinglists.json
+- name: Mailing Lists
   source: mbox
+  icon: default.png
+  index-patterns:
+  - panels/json/mbox-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/mailinglists.json
+- name: Mailing Lists
+  source: nntp
   icon: default.png
   index-patterns:
   - panels/json/mbox-index-pattern.json

--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -248,10 +248,13 @@ class TaskPanels(Task):
         """
         es_enrich = self.conf['es_enrichment']['url']
 
-        if data_sources and ('pipermail' in data_sources or 'hyperkitty' in data_sources):
-            # the dashboard for mbox and pipermail and hyperkitty are the same
+        mboxes_sources = set(['pipermail', 'hyperkitty', 'groupsio', 'nntp'])
+        if data_sources and any(x in data_sources for x in mboxes_sources):
             data_sources = list(data_sources)
             data_sources.append('mbox')
+        if data_sources and ('supybot' in data_sources):
+            data_sources = list(data_sources)
+            data_sources.append('irc')
         if data_sources and 'google_hits' in data_sources:
             data_sources = list(data_sources)
             data_sources.append('googlehits')
@@ -335,6 +338,18 @@ class TaskPanelsAliases(Task):
         },
         "pipermail": {
             "raw": ["pipermail-raw"],
+            "enrich": ["mbox", "mbox_enrich"]
+        },
+        "hyperkitty": {
+            "raw": ["hyperkitty-raw"],
+            "enrich": ["mbox", "mbox_enrich"]
+        },
+        "nntp": {
+            "raw": ["nntp-raw"],
+            "enrich": ["mbox", "mbox_enrich"]
+        },
+        "groupsio": {
+            "raw": ["groupsio-raw"],
             "enrich": ["mbox", "mbox_enrich"]
         },
         "phabricator": {

--- a/tests/test_task_panels.py
+++ b/tests/test_task_panels.py
@@ -95,7 +95,7 @@ class TestTaskPanelsMenu(unittest.TestCase):
 
         self.assertEqual(task.config, config)
 
-        self.assertEqual(len(task.panels_menu), 31)
+        self.assertEqual(len(task.panels_menu), 34)
 
         for entry in task.panels_menu:
             self.assertGreaterEqual(len(entry['index-patterns']), 0)

--- a/utils/menu.yaml
+++ b/utils/menu.yaml
@@ -126,7 +126,31 @@
   - name: Overview
     panel: panels/json/mediawiki.json
 - name: Mailing Lists
+  source: groupsio
+  icon: default.png
+  index-patterns:
+  - panels/json/mbox-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/mailinglists.json
+- name: Mailing Lists
+  source: hyperkitty
+  icon: default.png
+  index-patterns:
+  - panels/json/mbox-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/mailinglists.json
+- name: Mailing Lists
   source: mbox
+  icon: default.png
+  index-patterns:
+  - panels/json/mbox-index-pattern.json
+  menu:
+  - name: Overview
+    panel: panels/json/mailinglists.json
+- name: Mailing Lists
+  source: nntp
   icon: default.png
   index-patterns:
   - panels/json/mbox-index-pattern.json
@@ -253,7 +277,7 @@
   - name: Locations
     panel: panels/json/meetup_locations.json
 - name: Google Hits
-  source: google_hits
+  source: googlehits
   icon: default.png
   index-patterns:
   - panels/json/google-hits-index-pattern.json


### PR DESCRIPTION
This PR extends the menu.yml and task_panels by including mbox-type entries,
such as hyperkitty, groupsio and nntp. Thus, enabling to visualize information in the dashboards.