### PR TITLE
Fix visualizations for maniphest and googlehits data sources

### DIFF
--- a/menu.yaml
+++ b/menu.yaml
@@ -277,7 +277,7 @@
   - name: Locations
     panel: panels/json/meetup_locations.json
 - name: Google Hits
-  source: googlehits
+  source: google_hits
   icon: default.png
   index-patterns:
   - panels/json/google-hits-index-pattern.json

--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -279,6 +279,10 @@ class TaskPanels(Task):
             # stackexchange is called stackoverflow in panels
             data_sources = list(data_sources)
             data_sources.append('stackoverflow')
+        if data_sources and 'phabricator' in data_sources:
+            data_sources = list(data_sources)
+            data_sources.append('maniphest')
+
         try:
             import_dashboard(es_enrich, panel_file, data_sources=data_sources, strict=strict)
         except ValueError:


### PR DESCRIPTION
This PR enables to show maniphest and googlehits info in the overview and data status dashboards.