### PR TITLE
Fix default settings kibana

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,30 +6,16 @@ python:
 sudo: false
 
 services:
-  - elasticsearch
-#  - mysql
+  - docker
 
-# addons:
-#    mariadb: '10.0'
-
-# sleep to wait for Elasticsearch init
 before_install:
-  - sleep 5
+  - docker-compose up -d
+  - sleep 25
   - pip install pandas==0.18.1
   - pip install httpretty==0.8.6
   - pip install -r "requirements.txt"
   - pip install flake8
   - pip install coveralls
-
-# install:
-#   - ./setup.py install
-
-# To avoid: pymysql.err.OperationalError: (2013, 'Lost connection to MySQL server during query')
-# before_script:
-#  - echo -e "[mysqld]\nnet_read_timeout=180\nnet_write_timeout=180\nmax_allowed_packet=16M\nwait_timeout=2592000\ninteractive_timeout=2592000\nmax_connections=300" | sudo tee -a /etc/mysql/my.cnf
-#  - cat /etc/mysql/my.cnf
-#  - sudo service mysql restart
-#  - echo 'SHOW VARIABLES' | mysql -u root
 
 script:
   - flake8 .

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ SirMordred is the tool used to coordinate the execution of the GrimoireLab platf
  * **kibiter_default_index** (str: git): Default index pattern for Kibiter
  * **kibiter_time_from** (str: now-90d): Default time interval for Kibiter
  * **kibiter_url** (str: None): Kibiter URL
- * **kibiter_version** (str: None): Kibiter version
+ * **community** (bool: True): Include community section in dashboard
+ * **kafka** (bool: False): Include KIP section in dashboard
 ### [phases] 
 
  * **collection** (bool: True): Activate collection of items (**Required**)

--- a/doc/config.md
+++ b/doc/config.md
@@ -36,7 +36,8 @@ Use python mordred/config.py to generate it.
  * **kibiter_default_index** (str: git): Default index pattern for Kibiter
  * **kibiter_time_from** (str: now-90d): Default time interval for Kibiter
  * **kibiter_url** (str: None): Kibiter URL
- * **kibiter_version** (str: None): Kibiter version
+ * **community** (bool: True): Include community section in dashboard
+ * **kafka** (bool: False): Include KIP section in dashboard
 ### [phases] 
 
  * **collection** (bool: True): Activate collection of items (**Required**)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+elasticsearch:
+  restart: on-failure:5
+  image: bitergia/elasticsearch:6.1.0-secured
+  command: elasticsearch -Enetwork.bind_host=0.0.0.0 -Ehttp.max_content_length=2000mb
+  environment:
+    - ES_JAVA_OPTS=-Xms2g -Xmx2g
+  ports:
+    - 9200:9200
+
+kibiter:
+  restart: on-failure:5
+  image: bitergia/kibiter:6.1.0-secured
+  environment:
+    - PROJECT_NAME=Development
+    - NODE_OPTIONS=--max-old-space-size=1000
+    - ELASTICSEARCH_URL=https://elasticsearch:9200
+  links:
+    - elasticsearch
+  ports:
+    - 5601:5601

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -314,16 +314,10 @@ class Config():
                     "description": "Default index pattern for Kibiter"
                 },
                 "kibiter_url": {
-                    "optional": True,
+                    "optional": False,
                     "default": None,
                     "type": str,
                     "description": "Kibiter URL"
-                },
-                "kibiter_version": {
-                    "optional": True,
-                    "default": None,
-                    "type": str,
-                    "description": "Kibiter version"
                 },
                 "community": {
                     "optional": True,

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -243,14 +243,14 @@ class Task():
         Elasticsearch and Kibiter are paired (same major version for 5, 6).
 
         :param url: Elasticseearch url hosting Kibiter indices
-        :returns:   major version, as string
+        :returns: version number
         """
 
         try:
             res = self.grimoire_con.get(url)
             res.raise_for_status()
-            major = res.json()['version']['number'].split(".")[0]
+            version_number = res.json()['version']['number']
         except Exception:
             logger.error("Error retrieving Elasticsearch version: " + url)
             raise
-        return major
+        return version_number

--- a/tests/archives-test.cfg
+++ b/tests/archives-test.cfg
@@ -29,12 +29,10 @@ scroll_size = 100
 projects_file = archives-test-projects.json
 
 [es_collection]
-# url = http://bitergia:bitergia@localhost:9200
-url = http://localhost:9200
+url = https://admin:admin@localhost:9200
 
 [es_enrichment]
-# url = http://bitergia:bitergia@localhost:9200
-url = http://localhost:9200
+url = https://admin:admin@localhost:9200
 user =
 password =
 autorefresh = false
@@ -60,6 +58,7 @@ bots_names = [Beloved Bot]
 [panels]
 kibiter_time_from= "now-30y"
 kibiter_default_index= "git"
+kibiter_url = http://localhost:5601
 
 [phases]
 collection = true

--- a/tests/test.cfg
+++ b/tests/test.cfg
@@ -29,12 +29,10 @@ scroll_size = 100
 projects_file = test-projects.json
 
 [es_collection]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = https://admin:admin@localhost:9200
 
 [es_enrichment]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = https://admin:admin@localhost:9200
 autorefresh = false
 
 [sortinghat]
@@ -58,6 +56,7 @@ bots_names = [Beloved Bot]
 [panels]
 kibiter_time_from= "now-30y"
 kibiter_default_index= "git"
+kibiter_url = http://localhost:5601
 
 [phases]
 collection = true

--- a/tests/test_studies.cfg
+++ b/tests/test_studies.cfg
@@ -29,12 +29,10 @@ scroll_size = 100
 projects_file = test-projects.json
 
 [es_collection]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = https://admin:admin@localhost:9200
 
 [es_enrichment]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = https://admin:admin@localhost:9200
 autorefresh = false
 
 [sortinghat]
@@ -58,6 +56,7 @@ bots_names = [Beloved Bot]
 [panels]
 kibiter_time_from= "now-30y"
 kibiter_default_index= "git"
+kibiter_url = http://localhost:5601
 
 [phases]
 collection = true

--- a/tests/test_wrong.cfg
+++ b/tests/test_wrong.cfg
@@ -29,12 +29,10 @@ scroll_size = 100
 projects_file = test-projects.json
 
 [es_collection]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = https://admin:admin@localhost:9200
 
 [es_enrichment]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = https://admin:admin@localhost:9200
 autorefresh = false
 
 [sortinghat]
@@ -58,6 +56,7 @@ bots_names = [Beloved Bot]
 [panels]
 kibiter_time_from= "now-30y"
 kibiter_default_index= "git"
+kibiter_url = http://localhost:5601
 
 [phases]
 collection = true


### PR DESCRIPTION
This PR allows to set kibana configuration parameters, such as the default index pattern and time picker, which are taken directly from the mordred configuration file (.cfg). Furthermore, it removes support for old ES+Kibana versions (<6), which are not handled by the platform anymore.
The `config.py` has been changed accordingly, thus the parameter `kibiter_url`, within the section `panels` of the mordred cfg, is now mandatory. This change is needed to allow to configure default settings in kibana/kibiter dashboards. In addition, documentation (readme.md and config.md) has been aligned with the aforementioned changes.

Finally, in order to execute the tests to an environment closed to production containing also kibitier, the `travis.yml` has been changed. 
