### PR TITLE
Fix default settings kibana (second proposal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ SirMordred is the tool used to coordinate the execution of the GrimoireLab platf
 
  * **kibiter_default_index** (str: git): Default index pattern for Kibiter
  * **kibiter_time_from** (str: now-90d): Default time interval for Kibiter
- * **kibiter_url** (str: None): Kibiter URL
+ * **kibiter_url** (str): Kibiter URL (**Required**)
  * **kibiter_version** (str: None): Kibiter version
+ * **community** (bool: True): Include community section in dashboard
+ * **kafka** (bool: False): Include KIP section in dashboard
 ### [phases] 
 
  * **collection** (bool: True): Activate collection of items (**Required**)

--- a/doc/config.md
+++ b/doc/config.md
@@ -35,8 +35,10 @@ Use python mordred/config.py to generate it.
 
  * **kibiter_default_index** (str: git): Default index pattern for Kibiter
  * **kibiter_time_from** (str: now-90d): Default time interval for Kibiter
- * **kibiter_url** (str: None): Kibiter URL
+ * **kibiter_url** (str): Kibiter URL (**Required**)
  * **kibiter_version** (str: None): Kibiter version
+ * **community** (bool: True): Include community section in dashboard
+ * **kafka** (bool: False): Include KIP section in dashboard
 ### [phases] 
 
  * **collection** (bool: True): Activate collection of items (**Required**)

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -314,7 +314,7 @@ class Config():
                     "description": "Default index pattern for Kibiter"
                 },
                 "kibiter_url": {
-                    "optional": True,
+                    "optional": False,
                     "default": None,
                     "type": str,
                     "description": "Kibiter URL"

--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -236,6 +236,7 @@ class TaskPanels(Task):
         :param strict: only upload a dashboard if it is newer than the one already existing
         """
         es_enrich = self.conf['es_enrichment']['url']
+        kibana_url = self.conf['panels']['kibiter_url']
 
         mboxes_sources = set(['pipermail', 'hyperkitty', 'groupsio', 'nntp'])
         if data_sources and any(x in data_sources for x in mboxes_sources):
@@ -256,7 +257,7 @@ class TaskPanels(Task):
             data_sources.append('maniphest')
 
         try:
-            import_dashboard(es_enrich, panel_file, data_sources=data_sources, strict=strict)
+            import_dashboard(es_enrich, kibana_url, panel_file, data_sources=data_sources, strict=strict)
         except ValueError:
             logger.error("%s does not include release field. Not loading the panel.", panel_file)
         except RuntimeError:

--- a/tests/archives-test.cfg
+++ b/tests/archives-test.cfg
@@ -29,12 +29,12 @@ scroll_size = 100
 projects_file = archives-test-projects.json
 
 [es_collection]
-# url = http://bitergia:bitergia@localhost:9200
 url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
 
 [es_enrichment]
-# url = http://bitergia:bitergia@localhost:9200
 url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
 user =
 password =
 autorefresh = false
@@ -60,6 +60,7 @@ bots_names = [Beloved Bot]
 [panels]
 kibiter_time_from= "now-30y"
 kibiter_default_index= "git"
+kibiter_url = http://localhost:5601
 
 [phases]
 collection = true

--- a/tests/test.cfg
+++ b/tests/test.cfg
@@ -29,12 +29,12 @@ scroll_size = 100
 projects_file = test-projects.json
 
 [es_collection]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
 
 [es_enrichment]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
 autorefresh = false
 
 [sortinghat]
@@ -58,6 +58,7 @@ bots_names = [Beloved Bot]
 [panels]
 kibiter_time_from= "now-30y"
 kibiter_default_index= "git"
+kibiter_url = http://localhost:5601
 
 [phases]
 collection = true

--- a/tests/test_studies.cfg
+++ b/tests/test_studies.cfg
@@ -29,12 +29,12 @@ scroll_size = 100
 projects_file = test-projects.json
 
 [es_collection]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
 
 [es_enrichment]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
 autorefresh = false
 
 [sortinghat]
@@ -58,6 +58,7 @@ bots_names = [Beloved Bot]
 [panels]
 kibiter_time_from= "now-30y"
 kibiter_default_index= "git"
+kibiter_url = http://localhost:5601
 
 [phases]
 collection = true

--- a/tests/test_wrong.cfg
+++ b/tests/test_wrong.cfg
@@ -29,12 +29,12 @@ scroll_size = 100
 projects_file = test-projects.json
 
 [es_collection]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
 
 [es_enrichment]
-url = http://bitergia:bitergia@localhost:9200
-# url = http://localhost:9200
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
 autorefresh = false
 
 [sortinghat]
@@ -58,6 +58,7 @@ bots_names = [Beloved Bot]
 [panels]
 kibiter_time_from= "now-30y"
 kibiter_default_index= "git"
+kibiter_url = http://localhost:5601
 
 [phases]
 collection = true


### PR DESCRIPTION
This PR allows to set kibana configuration parameters, such as the default index pattern and time picker, which are taken directly from the mordred configuration file (.cfg). Furthermore, it keeps support for old ES+Kibana versions (<6).
The config.py has been changed accordingly, thus the parameter kibiter_url, within the section panels of the mordred cfg, is now mandatory. This change is needed to allow to configure default settings in kibana/kibiter dashboards. In addition, documentation (readme.md and config.md) has been aligned with the aforementioned changes.

Finally, tests have been changed according to the new aforementioned changes.