### PR TITLE
[panels] handle strict mode loading panels via setup.cfg

### DIFF
--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -301,6 +301,12 @@ class Config():
 
         params_panels = {
             "panels": {
+                "strict": {
+                    "optional": True,
+                    "default": True,
+                    "type": bool,
+                    "description": "Enable strict panels loading"
+                },
                 "kibiter_time_from": {
                     "optional": True,
                     "default": "now-90d",

--- a/tests/test_task_panels.py
+++ b/tests/test_task_panels.py
@@ -46,7 +46,7 @@ def check_import_dashboard_stackexchange(elastic_url, import_file, es_index=None
         raise RuntimeError('stackexchange present but stackoverflow no in data sources')
 
 
-def check_create_dashboard(panel_file, data_sources):
+def check_create_dashboard(panel_file, data_sources, strict):
     # data_sources must be only defined for Overview and Data Status panels
     if panel_file not in TaskPanels.panels_multi_ds and data_sources:
         raise RuntimeError('Creating %s with data sources filtering' % panel_file)


### PR DESCRIPTION
This code enhances `task_panels` to allow handling the way of loading panels according to a parameter (`strict`) within the setup.cfg. By default, the panels are loaded in strict mode, in order to disable it, it suffices to set `strict = false` within the section `panels` in the setup.cfg.