### PR TITLE
[task_panels] Add aliases to gitlab indexes

### DIFF
--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -36,7 +36,7 @@ from sirmordred.task import Task
 
 logger = logging.getLogger(__name__)
 
-# Header mandatory in Ellasticsearc 6
+# Header mandatory in ElasticSearch 6
 ES6_HEADER = {"Content-Type": "application/json"}
 KIBANA_SETTINGS_URL = '/api/kibana/settings'
 
@@ -91,7 +91,7 @@ GITLAB_ISSUES_MENU = {
     'menu': [
         {'name': 'Overview', 'panel': GITLAB_ISSUES_PANEL_OVERALL},
         {'name': 'Backlog', 'panel': GITLAB_ISSUES_PANEL_BACKLOG},
-        {'name': 'Timing', 'panel': GITLAB_ISSUES_IP}
+        {'name': 'Timing', 'panel': GITLAB_ISSUES_PANEL_TIMING}
     ]
 }
 
@@ -101,8 +101,8 @@ GITLAB_MERGES_PANEL_BACKLOG = "panels/json/gitlab_merge_requests_backlog.json"
 GITLAB_MERGES_PANEL_TIMING = "panels/json/gitlab_merge_requests_timing.json"
 GITLAB_MERGES_IP = "panels/json/gitlab_merge_requests-index-pattern.json"
 
-GITLAB_MERGESS_MENU = {
-    'name': 'GitLab Merge Requests',
+GITLAB_MERGES_MENU = {
+    'name': 'GitLab Merges',
     'source': GITLAB_MERGES,
     'icon': 'default.png',
     'index-patterns': [GITLAB_MERGES_IP],
@@ -425,6 +425,14 @@ class TaskPanelsAliases(Task):
             "raw": ["remo_activities-raw"],
             "enrich": ["remo-activities", "remo2-activities", "remo-activities_metadata__timestamp"]
         },
+        "gitlab:issue": {
+            "raw": ["gitlab_issue-raw"],
+            "enrich": ["gitlab", "gitlab_issue"]
+        },
+        "gitlab:merge": {
+            "raw": ["gitlab_merge-raw"],
+            "enrich": ["gitlab_merge"]
+        },
         "stackexchange": {
             "raw": ["stackexchange-raw"],
             "enrich": ["stackoverflow"]
@@ -555,7 +563,7 @@ class TaskPanelsMenu(Task):
             self.panels_menu.append(GITLAB_ISSUES_MENU)
 
         if self.conf['panels'][GITLAB_MERGES]:
-            self.panels_menu.append(GITLAB_ISSUES_MENU)
+            self.panels_menu.append(GITLAB_MERGES_MENU)
 
         if self.conf['panels'][MATTERMOST]:
             self.panels_menu.append(MATTERMOST_MENU)

--- a/utils/projects.json
+++ b/utils/projects.json
@@ -11,6 +11,12 @@
         ],
         "jenkins": [
            "https://build.opnfv.org/ci"
+        ],
+        "gitlab:issue": [
+            "https://gitlab.com/gitlab-org/gitlab-ce"
+        ],
+        "gitlab:merge": [
+            "https://gitlab.com/gitlab-org/gitlab-ce"
         ]
     }
 }

--- a/utils/setup.cfg
+++ b/utils/setup.cfg
@@ -32,10 +32,10 @@ projects_file = ./projects.json
 arthur = true
 arthur_url = http://127.0.0.1:8080
 redis_url = redis://localhost/8
-url = http://localhost:9200
+url = https://admin:admin@localhost:9200
 
 [es_enrichment]
-url = http://localhost:9200
+url = https://admin:admin@localhost:9200
 
 [sortinghat]
 host = 127.0.0.1
@@ -57,9 +57,11 @@ bots_names = [Beloved Bot]
 
 [panels]
 kibiter_time_from= "now-30y"
-kibiter_default_index= "git"
-community = true
+kibiter_default_index= "gitlab"
 kibiter_url = http://localhost:5601
+community = true
+gitlab_issues = true
+gitlab_merges = true
 
 [phases]
 collection = true
@@ -119,3 +121,18 @@ data_source_prs = github-prs
 [jenkins]
 raw_index = jenkins_test-raw
 enriched_index = jenkins_test
+
+[gitlab:issue]
+raw_index = test_gitlab-issue-raw
+enriched_index = test_gitlab-issue
+api-token = nsTwsxkTbnoJBbY3pC43
+no-archive = true
+sleep-for-rate = true
+
+[gitlab:merge]
+raw_index = test_gitlab-merge-raw
+enriched_index = test_gitlab-merge
+api-token = nsTwsxkTbnoJBbY3pC43
+no-archive = true
+category = merge_request
+sleep-for-rate = true


### PR DESCRIPTION
This code creates aliases for gitlab indexes to visualize gitlab data. The expected aliases are `gitlab` for issues and `gitlab_merge` for merge requests. The name of the backend sections should be `gitlab:issue` and `gitlab:merge`.