### PR TITLE
[tasks_panels] Disable kibiter 6 configuration

### DIFF
--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -229,6 +229,10 @@ class TaskPanels(Task):
         return True
 
     def __configure_kibiter_6(self):
+        # Disable kibiter 6 configuration
+        if True:
+            logger.error("Kibiter 6 configuration is temporarily disabled")
+            return True
 
         if 'panels' not in self.conf:
             logger.warning("Panels config not availble. Not configuring Kibiter.")


### PR DESCRIPTION
This code temporarily disables the configuration of the default index pattern and time picker for kibiter 6.