### PR TITLE
[panels] Change gitlab param names

### DIFF
--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -343,13 +343,13 @@ class Config():
                     "type": bool,
                     "description": "Enable kafka menu"
                 },
-                "gitlab_issues": {
+                "gitlab-issues": {
                     "optional": True,
                     "default": False,
                     "type": bool,
                     "description": "Enable GitLab issues menu"
                 },
-                "gitlab_merges": {
+                "gitlab-merges": {
                     "optional": True,
                     "default": False,
                     "type": bool,

--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -77,7 +77,7 @@ COMMUNITY_MENU = {
     ]
 }
 
-GITLAB_ISSUES = "gitlab_issues"
+GITLAB_ISSUES = "gitlab-issues"
 GITLAB_ISSUES_PANEL_OVERALL = "panels/json/gitlab_issues.json"
 GITLAB_ISSUES_PANEL_BACKLOG = "panels/json/gitlab_issues_backlog.json"
 GITLAB_ISSUES_PANEL_TIMING = "panels/json/gitlab_issues_timing.json"
@@ -95,7 +95,7 @@ GITLAB_ISSUES_MENU = {
     ]
 }
 
-GITLAB_MERGES = "gitlab_merges"
+GITLAB_MERGES = "gitlab-merges"
 GITLAB_MERGES_PANEL_OVERALL = "panels/json/gitlab_merge_requests.json"
 GITLAB_MERGES_PANEL_BACKLOG = "panels/json/gitlab_merge_requests_backlog.json"
 GITLAB_MERGES_PANEL_TIMING = "panels/json/gitlab_merge_requests_timing.json"


### PR DESCRIPTION
This code changes the names of the params used to load gitlab issues and merges. The previous names were not aligned to the convention used by kidash to identify a data source.