### PR TITLE
[doc] Update documentation for es_enrichement and onion studies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ SirMordred is the tool used to coordinate the execution of the GrimoireLab platf
 ### [es_enrichment] 
 
  * **autorefresh** (bool: True): Execute the autorefresh of identities
+ * **autorefresh_interval** (int: 2): Time interval (days) to autorefresh identities
  * **password** (str: None): Password for connection to Elasticsearch
  * **url** (str: http://172.17.0.1:9200): Elasticsearch URL (**Required**)
  * **user** (str: None): User for connection to Elasticsearch

--- a/doc/config.md
+++ b/doc/config.md
@@ -16,6 +16,7 @@ Use python mordred/config.py to generate it.
 ### [es_enrichment] 
 
  * **autorefresh** (bool: True): Execute the autorefresh of identities
+ * **autorefresh_interval** (int: 2): Time interval (days) to autorefresh identities
  * **password** (str: None): Password for connection to Elasticsearch
  * **url** (str: http://172.17.0.1:9200): Elasticsearch URL (**Required**)
  * **user** (str: None): User for connection to Elasticsearch

--- a/tests/test_studies.cfg
+++ b/tests/test_studies.cfg
@@ -67,8 +67,8 @@ enrichment = true
 panels = true
 
 [git]
-raw_index = git_test-raw
-enriched_index = git_test
+raw_index = ???
+enriched_index = ???
 studies = [enrich_demography:git, enrich_areas_of_code:git, enrich_onion:git]
 
 [enrich_demography:git]
@@ -98,15 +98,6 @@ no-archive = true       # default: false
 category = issue        # default: issue
 studies = [enrich_onion:github]
 
-[github:pulls]
-raw_index = ???
-enriched_index = ???
-api-token = ???         # default: none
-sleep-for-rate = true   # default: false
-no-archive = true       # default: false
-category = pull_request # default: issue
-studies = [enrich_pull_requests]
-
 [enrich_onion:github]
 in_index_iss = ???      # default: github_issues_onion-src
 in_index_prs = ???      # default: github_prs_onion-src
@@ -119,5 +110,38 @@ timeframe_field = ???   # default: grimoire_creation_date
 sort_on_field = ???     # default: metadata__timestamp
 no_incremental = true   # default: false
 
-[enrich_pull_requests]
-raw_issues_index = ???	# default: github_issues_raw. Name of the raw issues index used for github issues data source
+[gitlab:issue]
+raw_index = ???
+enriched_index = ???
+api-token = ???
+sleep-for-rate = true   # default: false
+no-archive = true       # default: false
+category = issue        # default: issue
+studies = [enrich_onion:gitlab-issue]
+
+[enrich_onion:gitlab-issue]
+in_index = ???
+out_index = ???
+data_source = ???       # gitlab-issues | gitlab-merges, otherwise a warning is thrown
+contribs_field = ???    # default: uuid)
+timeframe_field = ???   # default: grimoire_creation_date)
+sort_on_field = ???     # default: metadata__timestamp)
+no_incremental = true   # default: false
+
+[gitlab:merge]
+raw_index = ???
+enriched_index = ???
+api-token = ???
+sleep-for-rate = true     # default: false
+no-archive = true         # default: false
+category = merge_request  # default: issue
+studies = [enrich_onion:gitlab-merge]
+
+[enrich_onion:gitlab-merge]
+in_index = ???
+out_index = ???
+data_source = ???       # gitlab-issues | gitlab-merges, otherwise a warning is thrown
+contribs_field = ???    # default: uuid)
+timeframe_field = ???   # default: grimoire_creation_date)
+sort_on_field = ???     # default: metadata__timestamp)
+no_incremental = true   # default: false


### PR DESCRIPTION
This code updates the documentation for the `es_enrichment` section and onion studies.
The former includes a parameter `autorefresh_interval`, which defines the number of previous days (default 2) to be used to fetch modifications on the sortinghat database before executing the autorefresh. The latter contains a template to execute the onion study for gitlab merge requests and issues.