### PR TITLE
[menu] Remove onion index pattern from Git panel

### DIFF
--- a/menu.yaml
+++ b/menu.yaml
@@ -5,7 +5,6 @@
   index-patterns:
   - panels/json/git-index-pattern.json
   - panels/json/git_areas_of_code-index-pattern.json
-  - panels/json/all_onion-index-pattern.json
   menu:
   - name: Overview
     panel: panels/json/git.json

--- a/utils/menu.yaml
+++ b/utils/menu.yaml
@@ -5,7 +5,6 @@
   index-patterns:
   - panels/json/git-index-pattern.json
   - panels/json/git_areas_of_code-index-pattern.json
-  - panels/json/all_onion-index-pattern.json
   menu:
   - name: Overview
     panel: panels/json/git.json


### PR DESCRIPTION
This code removes the onion index pattern from the git panel. The micro mordred menu.yml has been changed accordingly.