### PR TITLE
[jenkins] Add support for node name cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Further information about Perceval backends parameters are available at:
 * **backend-param-2**: ..
 * **backend-param-n**: ..
 
+#### Enrichment params
+Some backend sections allow to specify specific enrichment options, listed below.
+
+##### [jenkins]
+* **node_regex**: regular expression for extracting node name from `builtOn` field. This
+  regular expression **must contain at least one group**. First group will be used to extract
+  node name. More groups are allowed but not used to extract anything else.
+
 ## Studies Sections
 
 In this section, a template of a study section is shown.

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -35,7 +35,8 @@ class Task():
     """ Basic class shared by all tasks """
 
     NO_BACKEND_FIELDS = ['enriched_index', 'raw_index', 'es_collection_url',
-                         'collect', 'pair-programming', 'fetch-archive', 'studies']
+                         'collect', 'pair-programming', 'fetch-archive', 'studies',
+                         'node_regex']
     PARAMS_WITH_SPACES = ['blacklist-jobs']
 
     def __init__(self, config):

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -115,10 +115,13 @@ class TaskEnrich(Task):
         no_incremental = False
         github_token = None
         pair_programming = False
+        node_regex = None
         if 'github' in cfg and 'backend_token' in cfg['github']:
             github_token = cfg['github']['backend_token']
         if 'git' in cfg and 'pair-programming' in cfg['git']:
             pair_programming = cfg['git']['pair-programming']
+        if 'jenkins' in cfg and 'node_regex' in cfg['jenkins']:
+            node_regex = cfg['jenkins']['node_regex']
         only_studies = False
         only_identities = False
 
@@ -171,6 +174,7 @@ class TaskEnrich(Task):
                                jenkins_rename_file=jenkins_rename_file,
                                unaffiliated_group=cfg['sortinghat']['unaffiliated_group'],
                                pair_programming=pair_programming,
+                               node_regex=node_regex,
                                studies_args=studies_args)
             except Exception as ex:
                 logger.error("Something went wrong producing enriched data for %s . "


### PR DESCRIPTION
A new parameter `node_regex` can be specified in `setup.cfg`,
jenkins section, to clean node names vi regular expression.
Resulting name will be group 1 of the given RE or original
node name if RE doesn't match.

Needs https://github.com/chaoss/grimoirelab-elk/pull/460