### PR TITLE
[jira] Add index pattern for closed issues

### DIFF
--- a/menu.yaml
+++ b/menu.yaml
@@ -77,6 +77,7 @@
   icon: default.png
   index-patterns:
   - panels/json/jira-index-pattern.json
+  - panels/json/jira_resolution_date-index-pattern.json
   menu:
   - name: Overview
     panel: panels/json/jira.json

--- a/utils/menu.yaml
+++ b/utils/menu.yaml
@@ -77,6 +77,7 @@
   icon: default.png
   index-patterns:
   - panels/json/jira-index-pattern.json
+  - panels/json/jira_resolution_date-index-pattern.json
   menu:
   - name: Overview
     panel: panels/json/jira.json


### PR DESCRIPTION
This index pattern allows to build widgets based on
`resolution_date` instead of `grimoire_creation_date`.

Needed for: https://github.com/chaoss/grimoirelab-sigils/pull/284