### PR TITLE
[sirmordred] Set elasticsearch logging level to INFO

### DIFF
--- a/bin/sirmordred
+++ b/bin/sirmordred
@@ -109,6 +109,7 @@ def setup_logs(logs_dir, debug_mode, log_file_handler, max_bytes, backup_count):
 
     logging.getLogger('requests').setLevel(logging.WARNING)
     logging.getLogger('urrlib3').setLevel(logging.WARNING)
+    logging.getLogger('elasticsearch').setLevel(logging.INFO)
 
     return logger
 

--- a/utils/micro.py
+++ b/utils/micro.py
@@ -33,7 +33,9 @@ from sirmordred.task_panels import TaskPanels, TaskPanelsMenu, TaskPanelsAliases
 from sirmordred.task_projects import TaskProjects
 
 DEBUG_LOG_FORMAT = "[%(asctime)s - %(name)s - %(levelname)s] - %(message)s"
+
 logging.basicConfig(level=logging.DEBUG, format=DEBUG_LOG_FORMAT)
+logging.getLogger('elasticsearch').setLevel(logging.INFO)
 
 
 def micro_mordred(cfg_path, backend_sections, raw, arthur, identities, enrich, panels):


### PR DESCRIPTION
Those componens which use elasticsearch library are writting each item to the log due to logging library is configured to DEBUG level.

To fix this problem INFO level has been set for the messages written by elasticsearch in sirmordred and micro-mordred scripts.

Fixes #245