### PR TITLE
Make standard logs more readable

### DIFF
--- a/bin/sirmordred
+++ b/bin/sirmordred
@@ -86,26 +86,10 @@ def setup_logs(logs_dir, debug_mode, log_file_handler, max_bytes, backup_count):
     logger.addHandler(fh)
     logger.addHandler(ch)
 
-    pfh_filepath = os.path.join(logs_dir,'perceval.log')
-    pfh = log_file_handler(pfh_filepath, **log_file_handler_kwargs)
-    fh.setLevel(logging_mode)
-    pfh.setFormatter(formatter)
-    perceval_logger = logging.getLogger('perceval')
-    perceval_logger.addHandler(pfh)
-
-    gfh_filepath = os.path.join(logs_dir,'grimoire.log')
-    gfh = log_file_handler(gfh_filepath, **log_file_handler_kwargs)
-    fh.setLevel(logging_mode)
-    gfh.setFormatter(formatter)
-    perceval_logger = logging.getLogger('grimoire')
-    perceval_logger.addHandler(gfh)
-
-    wfh_filepath = os.path.join(logs_dir,'sirmordred.log')
-    wfh = log_file_handler(wfh_filepath, **log_file_handler_kwargs)
-    wfh.setLevel(logging_mode)
-    wfh.setFormatter(formatter)
-    workflow_logger = logging.getLogger('sirmordred')
-    workflow_logger.addHandler(wfh)
+    # this is needed because the log messages of the grimoire_elk library are to verbose
+    if not debug_mode:
+        logging.getLogger('perceval').setLevel(logging.WARNING)
+        logging.getLogger('grimoire_elk').setLevel(logging.WARNING)
 
     logging.getLogger('requests').setLevel(logging.WARNING)
     logging.getLogger('urrlib3').setLevel(logging.WARNING)

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -76,7 +76,7 @@ class TaskRawDataCollection(Task):
             return
 
         t2 = time.time()
-        logger.info('[%s] raw data collection starts', self.backend_section)
+        logger.info('[%s] collection phase starts', self.backend_section)
         print("Collection for {}: starting...".format(self.backend_section))
         clean = False
 
@@ -103,7 +103,7 @@ class TaskRawDataCollection(Task):
             url = p2o_args['url']
             backend_args = self._compose_perceval_params(self.backend_section, repo)
             logger.debug(backend_args)
-            logger.debug('[%s] collection starts for %s', self.backend_section, repo)
+            logger.info('[%s] collection starts for %s', self.backend_section, repo)
             es_col_url = self._get_collection_url()
             ds = self.backend_section
             backend = self.get_backend(self.backend_section)
@@ -116,11 +116,11 @@ class TaskRawDataCollection(Task):
                              "Using the backend_args: %s " % (ds, url, str(backend_args)))
                 traceback.print_exc()
                 raise DataCollectionError('Failed to collect data from %s' % url)
+            logger.info('[%s] collection finished for %s', self.backend_section, repo)
 
         t3 = time.time()
-
         spent_time = time.strftime("%H:%M:%S", time.gmtime(t3 - t2))
-        logger.info('[%s] Data collection finished in %s',
+        logger.info('[%s] collection phase finished in %s',
                     self.backend_section, spent_time)
         print("Collection for {}: finished after {} hours".format(self.backend_section,
                                                                   spent_time))

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -101,7 +101,7 @@ class TaskEnrich(Task):
         time_start = time.time()
 
         # logger.info('%s starts for %s ', 'enrichment', self.backend_section)
-        logger.info('[%s] enrichment starts', self.backend_section)
+        logger.info('[%s] enrichment phase starts', self.backend_section)
         print("Enrichment for {}: starting...".format(self.backend_section))
 
         cfg = self.config.get_conf()
@@ -146,9 +146,9 @@ class TaskEnrich(Task):
                     self.conf[self.backend_section]['studies']:
                 studies_args = self.__load_studies()
 
+            logger.info('[%s] enrichment starts for %s', self.backend_section, repo)
             try:
                 es_col_url = self._get_collection_url()
-                logger.debug('[%s] enrichment starts for %s', self.backend_section, repo)
                 backend = self.get_backend(self.backend_section)
                 enrich_backend(es_col_url, self.clean, backend, backend_args,
                                cfg[self.backend_section]['raw_index'],
@@ -182,6 +182,8 @@ class TaskEnrich(Task):
                 logger.error("Exception: %s", ex)
                 raise DataEnrichmentError('Failed to produce enriched data for ' + self.backend_section)
 
+            logger.info('[%s] enrichment finished for %s', self.backend_section, repo)
+
             # Let's try to create the aliases for the enriched index
             if not self.enrich_aliases:
                 logger.debug("Creating aliases after enrich")
@@ -192,7 +194,7 @@ class TaskEnrich(Task):
                 self.enrich_aliases = True
 
         spent_time = time.strftime("%H:%M:%S", time.gmtime(time.time() - time_start))
-        logger.info('[%s] enrichment finished in %s', self.backend_section, spent_time)
+        logger.info('[%s] enrichment phase finished in %s', self.backend_section, spent_time)
         print("Enrichment for {}: finished after {} hours".format(self.backend_section,
                                                                   spent_time))
 


### PR DESCRIPTION
Change the log level of the Perceval and GrimoireELK libraries when the parameter debug mode is set to false, this way the Mordred log is more readable. The files with the logs for those libraries are no longer used, so the tool will just write the logs to the current file all.log.

I thought about changing the logging level for GrimoireELK to avoid doing this, but this is going to take a lot of time and in any case, those messages should not be printed if everything works OK.

Besides changing the log level, the second small commit adds more info to the logging INFO messages to know the origin field both for the enrichment and collection phase. This is going to make easier to know what phase is being executed by anyone monitoring the log file.