### PR TITLE
Unify the log debug messages printed by the threads

### DIFF
--- a/sirmordred/sirmordred.py
+++ b/sirmordred/sirmordred.py
@@ -223,8 +223,6 @@ class SirMordred:
                     global_t.append(t)
             return backend_t, global_t
 
-        logger.debug('Tasks Manager starting .. ')
-
         backend_tasks, global_tasks = _split_tasks(tasks_cls)
         logger.debug('backend_tasks = %s' % (backend_tasks))
         logger.debug('global_tasks = %s' % (global_tasks))
@@ -258,7 +256,6 @@ class SirMordred:
         if wait_for_threads:
             time.sleep(1)  # Give enough time create and run all threads
             stopper.set()  # All threads must stop in the next iteration
-            logger.debug(" Waiting for all threads to complete. This could take a while ..")
 
         # Wait for all threads to complete
         for t in threads:
@@ -267,13 +264,13 @@ class SirMordred:
         # Checking for exceptions in threads to log them
         self.__check_queue_for_errors()
 
-        logger.debug(" Task manager and all its tasks (threads) finished!")
+        logger.debug("[thread:main] All threads (and their tasks) are finished")
 
     def __check_queue_for_errors(self):
         try:
             exc = TasksManager.COMM_QUEUE.get(block=False)
         except queue.Empty:
-            logger.debug("No exceptions in threads. Let's continue ..")
+            logger.debug("[thread:main] No exceptions in threads queue. Let's continue ..")
         else:
             exc_type, exc_obj, exc_trace = exc
             # deal with the exception


### PR DESCRIPTION
After having a look at the Mordred scheduler I've realized that the debug messages we have in the module named `task_manager` are not helping at all to debug how the threads are working. This is why I decided to improve them.

These changes unify the log debugging messages printed by the threads (and from the main process) using a thread identifier and a more clear text. See the example below:
```
# tail -f logs/all.log|grep thread                                                                                                                                                                                                   
2018-11-09 16:15:27,110 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Thread starts
2018-11-09 16:15:27,285 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Tasks will be executed in this order: [<sirmordred.task_panels.TaskPanels object at 0x7f4537dde710>, <sirmordred.task_panels.TaskPanelsMenu object at 0x7f4537594940>]                                                   
2018-11-09 16:15:31,465 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Tasks finished: <sirmordred.task_panels.TaskPanels object at 0x7f4537dde710>
2018-11-09 16:15:31,622 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Tasks finished: <sirmordred.task_panels.TaskPanelsMenu object at 0x7f4537594940>
2018-11-09 16:15:31,623 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Thread is exiting
2018-11-09 16:15:31,623 - sirmordred.sirmordred - DEBUG - [thread:main] No exceptions in threads queue. Let's continue ..
2018-11-09 16:15:31,623 - sirmordred.sirmordred - DEBUG - [thread:main] All threads (and their tasks) are finished
2018-11-09 16:15:31,626 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Thread starts
2018-11-09 16:15:31,627 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Tasks will be executed in this order: [<sirmordred.task_identities.TaskInitSortingHat object at 0x7f4537598780>]
2018-11-09 16:15:32,677 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Tasks finished: <sirmordred.task_identities.TaskInitSortingHat object at 0x7f4537598780>
2018-11-09 16:15:32,678 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Thread is exiting
2018-11-09 16:15:32,678 - sirmordred.sirmordred - DEBUG - [thread:main] No exceptions in threads queue. Let's continue ..
2018-11-09 16:15:32,678 - sirmordred.sirmordred - DEBUG - [thread:main] All threads (and their tasks) are finished
2018-11-09 16:15:32,678 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Thread starts
2018-11-09 16:15:32,679 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Tasks will be executed in this order: [<sirmordred.task_projects.TaskProjects object at 0x7f4537598860>]
2018-11-09 16:15:33,681 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Tasks finished: <sirmordred.task_projects.TaskProjects object at 0x7f4537598860>
2018-11-09 16:15:33,681 - sirmordred.task_manager - DEBUG - [thread:139935266682624][Global tasks] Thread is exiting
2018-11-09 16:15:33,681 - sirmordred.sirmordred - DEBUG - [thread:main] No exceptions in threads queue. Let's continue ..
2018-11-09 16:15:33,681 - sirmordred.sirmordred - DEBUG - [thread:main] All threads (and their tasks) are finished
2018-11-09 16:15:33,682 - sirmordred.task_manager - DEBUG - [thread:139935266682624][dockerhub] Thread starts
2018-11-09 16:15:33,683 - sirmordred.task_manager - DEBUG - [thread:139935257503488][git] Thread starts
2018-11-09 16:15:33,688 - sirmordred.task_manager - DEBUG - [thread:139935249110784][github] Thread starts
2018-11-09 16:15:33,689 - sirmordred.task_manager - DEBUG - [thread:139935240718080][phabricator] Thread starts
2018-11-09 16:15:33,697 - sirmordred.task_manager - DEBUG - [thread:139935232325376][slack] Thread starts
2018-11-09 16:15:33,697 - sirmordred.task_manager - DEBUG - [thread:139935223932672][Global tasks] Thread starts
2018-11-09 16:15:33,747 - sirmordred.task_manager - DEBUG - [thread:139935266682624][dockerhub] Tasks will be executed in this order: [<sirmordred.task_collection.TaskRawDataCollection object at 0x7f4537598be0>, <sirmordred.task_enrich.TaskEnrich object at 0x7f453759e978>, <sirmordred.task_panels.TaskPanelsAliases object at 0x7f453759bbe0>]
2018-11-09 16:15:33,802 - sirmordred.task_manager - DEBUG - [thread:139935257503488][git] Tasks will be executed in this order: [<sirmordred.task_collection.TaskRawDataCollection object at 0x7f453759eac8>, <sirmordred.task_enrich.TaskEnrich object at 0x7f453759b908>, <sirmordred.task_panels.TaskPanelsAliases object
at 0x7f4537594908>]
2018-11-09 16:15:33,844 - sirmordred.task_manager - DEBUG - [thread:139935240718080][phabricator] Tasks will be executed in this order: [<sirmordred.task_collection.TaskRawDataCollection object at 0x7f4537dde160>, <sirmordred.task_enrich.TaskEnrich object at 0x7f4537dde748>, <sirmordred.task_panels.TaskPanelsAliases object at 0x7f4537598a20>]
2018-11-09 16:15:33,885 - sirmordred.task_manager - DEBUG - [thread:139935249110784][github] Tasks will be executed in this order: [<sirmordred.task_collection.TaskRawDataCollection object at 0x7f453759bef0>, <sirmordred.task_enrich.TaskEnrich object at 0x7f454e58a780>, <sirmordred.task_panels.TaskPanelsAliases object at 0x7f4537dd1b38>]
2018-11-09 16:15:33,937 - sirmordred.task_manager - DEBUG - [thread:139935232325376][slack] Tasks will be executed in this order: [<sirmordred.task_collection.TaskRawDataCollection object at 0x7f454e045278>, <sirmordred.task_enrich.TaskEnrich object at 0x7f4537580d30>, <sirmordred.task_panels.TaskPanelsAliases object at 0x7f453759e080>]
2018-11-09 16:15:34,004 - sirmordred.task_manager - DEBUG - [thread:139935223932672][Global tasks] Tasks will be executed in this order: [<sirmordred.task_projects.TaskProjects object at 0x7f4537580160>, <sirmordred.task_identities.TaskIdentitiesLoad object at 0x7f4537580be0>, <sirmordred.task_identities.TaskIdentitiesMerge object at 0x7f4537580f60>, <sirmordred.task_identities.TaskIdentitiesExport object at 0x7f4537dfbe48>]
2018-11-09 16:15:35,006 - sirmordred.task_manager - DEBUG - [thread:139935223932672][Global tasks] Tasks finished: <sirmordred.task_projects.TaskProjects object at 0x7f4537580160>
2018-11-09 16:15:35,753 - sirmordred.task_manager - DEBUG - [thread:139935240718080][phabricator] Tasks finished: <sirmordred.task_collection.TaskRawDataCollection object at 0x7f4537dde160>
2018-11-09 16:15:39,832 - sirmordred.task_manager - DEBUG - [thread:139935223932672][Global tasks] Tasks finished: <sirmordred.task_identities.TaskIdentitiesLoad object at 0x7f4537580be0>
2018-11-09 16:15:43,980 - sirmordred.task_manager - DEBUG - [thread:139935232325376][slack] Tasks finished: <sirmordred.task_collection.TaskRawDataCollection object at 0x7f454e045278>
2018-11-09 16:15:44,684 - sirmordred.task_manager - DEBUG - [thread:139935266682624][dockerhub] Tasks finished: <sirmordred.task_collection.TaskRawDataCollection object at 0x7f4537598be0>
2018-11-09 16:15:49,234 - sirmordred.task_manager - DEBUG - [thread:139935223932672][Global tasks] Tasks finished: <sirmordred.task_identities.TaskIdentitiesMerge object at 0x7f4537580f60>
2018-11-09 16:15:49,235 - sirmordred.task_manager - DEBUG - [thread:139935223932672][Global tasks] Tasks finished: <sirmordred.task_identities.TaskIdentitiesExport object at 0x7f4537dfbe48>
2018-11-09 16:15:49,235 - sirmordred.task_manager - DEBUG - [thread:139935223932672][Global tasks] sleeping for 1800 seconds
2018-11-09 16:15:59,462 - sirmordred.task_manager - DEBUG - [thread:139935266682624][dockerhub] Tasks finished: <sirmordred.task_enrich.TaskEnrich object at 0x7f453759e978>
2018-11-09 16:15:59,485 - sirmordred.task_manager - DEBUG - [thread:139935266682624][dockerhub] Tasks finished: <sirmordred.task_panels.TaskPanelsAliases object at 0x7f453759bbe0>
2018-11-09 16:15:59,486 - sirmordred.task_manager - DEBUG - [thread:139935266682624][dockerhub] sleeping for 1200 seconds
```