### PR TITLE
[aliases] Add aliases_file to cfg

### DIFF
--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -32,6 +32,10 @@ from grimoire_elk.utils import get_connectors
 logger = logging.getLogger(__name__)
 
 
+ALIASES_JSON = 'aliases.json'
+PROJECTS_JSON = 'projects.json'
+
+
 class Config():
     """Class aimed to manage sirmordred configuration"""
 
@@ -149,15 +153,20 @@ class Config():
                     "default": 100,
                     "type": int,
                     "description": "Number of items to read from Elasticsearch when scrolling"
+                },
+                "aliases_file": {
+                    "optional": True,
+                    "default": ALIASES_JSON,
+                    "type": str,
+                    "description": "JSON file to define aliases for raw and enriched indexes"
                 }
-
             }
         }
         params_projects = {
             "projects": {
                 "projects_file": {
                     "optional": True,
-                    "default": "projects.json",
+                    "default": PROJECTS_JSON,
                     "type": str,
                     "description": "Projects file path with repositories to be collected group by projects"
                 },

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -39,7 +39,6 @@ class Task():
                          'collect', 'pair-programming', 'fetch-archive', 'studies',
                          'node_regex']
     PARAMS_WITH_SPACES = ['blacklist-jobs']
-    ALIASES_JSON = 'aliases.json'
 
     def __init__(self, config):
         self.backend_section = None
@@ -51,9 +50,9 @@ class Task():
         self.db_host = self.conf['sortinghat']['host']
         self.grimoire_con = grimoire_con(conn_retries=12)  # 30m retry
 
-    def load_aliases_from_json(self):
-
-        with open(self.ALIASES_JSON, 'r') as f:
+    @staticmethod
+    def load_aliases_from_json(aliases_json):
+        with open(aliases_json, 'r') as f:
             try:
                 aliases = json.load(f)
             except Exception as ex:

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -64,7 +64,8 @@ class TaskRawDataCollection(Task):
 
     def select_aliases(self, cfg, backend_section):
 
-        aliases = self.load_aliases_from_json()
+        aliases_file = cfg['general']['aliases_file']
+        aliases = self.load_aliases_from_json(aliases_file)
         if backend_section in aliases:
             found = aliases[backend_section]['raw']
         else:

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -70,7 +70,8 @@ class TaskEnrich(Task):
 
     def select_aliases(self, cfg, backend_section):
 
-        aliases = self.load_aliases_from_json()
+        aliases_file = cfg['general']['aliases_file']
+        aliases = self.load_aliases_from_json(aliases_file)
         if backend_section in aliases:
             found = aliases[backend_section]['enrich']
         else:

--- a/tests/archives-test.cfg
+++ b/tests/archives-test.cfg
@@ -24,6 +24,7 @@ logs_dir = logs
 bulk_size = 100
 # Number of items to get from Elasticsearch when scrolling
 scroll_size = 100
+aliases_file = ./aliases.json
 
 [projects]
 projects_file = archives-test-projects.json

--- a/tests/test_studies.cfg
+++ b/tests/test_studies.cfg
@@ -24,6 +24,7 @@ logs_dir = logs
 bulk_size = 100
 # Number of items to get from Elasticsearch when scrolling
 scroll_size = 100
+aliases_file = ./aliases.json
 
 [projects]
 projects_file = test-projects.json

--- a/tests/test_wrong.cfg
+++ b/tests/test_wrong.cfg
@@ -24,6 +24,7 @@ logs_dir = logs
 bulk_size = 100
 # Number of items to get from Elasticsearch when scrolling
 scroll_size = 100
+aliases_file = ./aliases.json
 
 [projects]
 projects_file = test-projects.json


### PR DESCRIPTION
This code enhances the setup.cfg to include a new param `aliases_file`, which allows to declare the file path of a JSON file containing aliases for raw and enriched indexes.