### PR TITLE
[task_enrich] Propagate cfg section name to ELK

### DIFF
--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -163,6 +163,7 @@ class TaskEnrich(Task):
             try:
                 es_col_url = self._get_collection_url()
                 enrich_backend(es_col_url, self.clean, backend, backend_args,
+                               self.backend_section,
                                cfg[self.backend_section]['raw_index'],
                                cfg[self.backend_section]['enriched_index'],
                                None,  # projects_db is deprecated


### PR DESCRIPTION
This PR allows to propagate the cfg section name of a backend to ELK. This information is needed to correctly retrieve the project name within the projects.json. 
This PR should be reviewed together with https://github.com/chaoss/grimoirelab-elk/pull/530