### PR TITLE
[mordred] Make global sources configurable from cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ SirMordred is the tool used to coordinate the execution of the GrimoireLab platf
  * **update** (bool: False): Execute the tasks in loop (**Required**)
  * **aliases_file** (str: ./aliases.json): JSON file to define aliases for raw and enriched indexes
  * **menu_file** (str: ./menu.yaml): YAML file to define the menus to be shown in Kibiter
+ * **global_data_sources** (list: bugzilla, bugzillarest, confluence, discourse, gerrit, jenkins, jira): List of data sources collected globally, they are declared in the section 'unknown' of the projects.json
 ### [panels] 
 
  * **community** (bool: True): Include community section in dashboard

--- a/doc/config.md
+++ b/doc/config.md
@@ -34,6 +34,7 @@ Use python mordred/config.py to generate it.
  * **update** (bool: False): Execute the tasks in loop (**Required**)
  * **aliases_file** (str: ./aliases.json): JSON file to define aliases for raw and enriched indexes
  * **menu_file** (str: ./menu.yaml): YAML file to define the menus to be shown in Kibiter
+ * **global_data_sources** (list: bugzilla, bugzillarest, confluence, discourse, gerrit, jenkins, jira): List of data sources collected globally, they are declared in the section 'unknown' of the projects.json
 ### [panels] 
 
  * **community** (bool: True): Include community section in dashboard

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -173,7 +173,8 @@ class Config():
                     "optional": True,
                     "default": GLOBAL_DATA_SOURCES,
                     "type": list,
-                    "description": "List of data sources collected and enriched globally"
+                    "description": "List of data sources collected globally, they are declared in the "
+                                   "section 'unknown' of the projects.json"
                 }
             }
         }
@@ -666,7 +667,8 @@ class Config():
         return studies
 
     def get_global_data_sources(self):
-        """ Data sources that are collected and enriched globally """
+        """Data sources that are collected globally, they are declared
+        in the section 'unknown' of the projects.json"""
 
         return self.conf['general']['global_data_sources']
 

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 MENU_YAML = 'menu.yaml'
 ALIASES_JSON = 'aliases.json'
 PROJECTS_JSON = 'projects.json'
+GLOBAL_DATA_SOURCES = ['bugzilla', 'bugzillarest', 'confluence',
+                       'discourse', 'gerrit', 'jenkins', 'jira']
 
 
 class Config():
@@ -166,6 +168,12 @@ class Config():
                     "default": MENU_YAML,
                     "type": str,
                     "description": "YAML file to define the menus to be shown in Kibiter"
+                },
+                "global_data_sources": {
+                    "optional": True,
+                    "default": GLOBAL_DATA_SOURCES,
+                    "type": list,
+                    "description": "List of data sources collected and enriched globally"
                 }
             }
         }
@@ -657,11 +665,10 @@ class Config():
 
         return studies
 
-    @classmethod
-    def get_global_data_sources(cls):
-        """ Data sources than are collected and enriched globally """
+    def get_global_data_sources(self):
+        """ Data sources that are collected and enriched globally """
 
-        return ['bugzilla', 'bugzillarest', 'confluence', 'discourse', 'gerrit', 'jenkins', 'jira']
+        return self.conf['general']['global_data_sources']
 
     def get_data_sources(self):
         data_sources = []

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -237,7 +237,8 @@ class Task():
         clean = False
 
         from .task_projects import TaskProjects
-        repos = TaskProjects.get_repos_by_backend_section(self.backend_section)
+        global_data_sources = self.config.get_global_data_sources()
+        repos = TaskProjects.get_repos_by_backend_section(global_data_sources, self.backend_section)
         if len(repos) == 1:
             # Support for filter raw when we have one repo
             (filter_raw, filters_raw_prefix) = self.__filters_raw(repos[0])

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -96,7 +96,8 @@ class TaskRawDataCollection(Task):
             fetch_archive = True
 
         # repos could change between executions because changes in projects
-        repos = TaskProjects.get_repos_by_backend_section(self.backend_section)
+        global_data_sources = self.config.get_global_data_sources()
+        repos = TaskProjects.get_repos_by_backend_section(global_data_sources, self.backend_section)
 
         if not repos:
             logger.warning("No collect repositories for %s", self.backend_section)
@@ -392,7 +393,8 @@ class TaskRawDataArthurCollection(Task):
             fetch_archive = True
 
         # repos could change between executions because changes in projects
-        repos = TaskProjects.get_repos_by_backend_section(self.backend_section)
+        global_data_sources = self.config.get_global_data_sources()
+        repos = TaskProjects.get_repos_by_backend_section(global_data_sources, self.backend_section)
 
         if not repos:
             logger.warning("No collect repositories for %s", self.backend_section)

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -136,7 +136,8 @@ class TaskEnrich(Task):
         only_identities = False
 
         # repos could change between executions because changes in projects
-        repos = TaskProjects.get_repos_by_backend_section(self.backend_section)
+        global_data_sources = self.config.get_global_data_sources()
+        repos = TaskProjects.get_repos_by_backend_section(global_data_sources, self.backend_section)
 
         if not repos:
             logger.warning("No enrich repositories for %s", self.backend_section)

--- a/sirmordred/task_projects.py
+++ b/sirmordred/task_projects.py
@@ -31,7 +31,6 @@ import requests
 
 from copy import deepcopy
 
-from sirmordred.config import Config
 from sirmordred.task import Task
 from sirmordred.eclipse_projects_lib import compose_title, compose_projects_json
 
@@ -69,7 +68,7 @@ class TaskProjects(Task):
         return cls.projects_last_diff
 
     @classmethod
-    def get_repos_by_backend_section(cls, backend_section):
+    def get_repos_by_backend_section(cls, global_data_sources, backend_section):
         """ return list with the repositories for a backend_section """
         repos = []
         projects = TaskProjects.get_projects()
@@ -77,7 +76,7 @@ class TaskProjects(Task):
         for pro in projects:
             if backend_section in projects[pro]:
                 backend = Task.get_backend(backend_section)
-                if backend in Config.get_global_data_sources() and cls.GLOBAL_PROJECT in projects \
+                if backend in global_data_sources and cls.GLOBAL_PROJECT in projects \
                         and pro != cls.GLOBAL_PROJECT:
                     logger.debug("Skip global data source %s for project %s",
                                  backend, pro)

--- a/sirmordred/task_track.py
+++ b/sirmordred/task_track.py
@@ -53,7 +53,10 @@ class TaskTrackItems(Task):
 
         # We need to track the items in all git repositories from OPNFV
         git_repos = []
-        repos_raw = TaskProjects.get_repos_by_backend_section("git")
+
+        global_data_sources = self.config.get_global_data_sources()
+        repos_raw = TaskProjects.get_repos_by_backend_section(global_data_sources, "git")
+
         # git://git.opnfv.org/apex -> https://git.opnfv.org/apex/plain/UPSTREAM
         for repo in repos_raw:
             repo = repo.replace("git://", "https://")

--- a/tests/test_task_projects.py
+++ b/tests/test_task_projects.py
@@ -105,47 +105,50 @@ class TestTaskProjects(unittest.TestCase):
                                      if sect and sect.startswith(backend_section)]))
         backend_sections.sort()
         backend = backend_sections[0]
-        repos = task.get_repos_by_backend_section(backend)
+
+        global_data_sources = config.get_global_data_sources()
+
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'askbot')
         self.assertEqual(repos, ['https://ask.puppet.com'])
 
         backend = backend_sections[1]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'bugzilla')
         self.assertEqual(repos, ['https://bugs.eclipse.org/bugs/'])
 
         backend = backend_sections[2]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'bugzillarest')
         self.assertEqual(repos, ['https://bugzilla.mozilla.org'])
 
         backend = backend_sections[3]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'confluence')
         self.assertEqual(repos, ['https://wiki.open-o.org/'])
 
         backend = backend_sections[4]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'discourse')
         self.assertEqual(repos, ['https://foro.mozilla-hispano.org/'])
 
         backend = backend_sections[5]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'dockerhub')
         self.assertEqual(repos, ['bitergia kibiter'])
 
         backend = backend_sections[6]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'functest')
         self.assertEqual(repos, ['http://testresults.opnfv.org/test/'])
 
         backend = backend_sections[7]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'gerrit')
         self.assertEqual(repos, ['review.openstack.org'])
 
         backend = backend_sections[8]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'git')
         self.assertEqual(repos,
                          ["https://github.com/VizGrimoire/GrimoireLib "
@@ -153,125 +156,125 @@ class TestTaskProjects(unittest.TestCase):
                           "https://github.com/MetricsGrimoire/CMetrics"])
 
         backend = backend_sections[9]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'github')
         self.assertEqual(repos, ['https://github.com/grimoirelab/perceval'])
 
         backend = backend_sections[10]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'github:pull')
         self.assertEqual(repos, ['https://github.com/grimoirelab/perceval'])
 
         backend = backend_sections[11]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'gitlab')
         self.assertEqual(repos, ['https://gitlab.com/inkscape/inkscape-web'])
 
         backend = backend_sections[12]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'google_hits')
         self.assertEqual(repos, ['bitergia grimoirelab'])
 
         backend = backend_sections[13]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'hyperkitty')
         self.assertEqual(repos,
                          ['https://lists.mailman3.org/archives/list/mailman-users@mailman3.org'])
 
         backend = backend_sections[14]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'jenkins')
         self.assertEqual(repos, ['https://build.opnfv.org/ci'])
 
         backend = backend_sections[15]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'jira')
         self.assertEqual(repos, ['https://jira.opnfv.org'])
 
         backend = backend_sections[16]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'mattermost')
         self.assertEqual(repos, ['https://chat.openshift.io 8j366ft5affy3p36987pcugaoa'])
 
         backend = backend_sections[17]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'mattermost:group1')
         self.assertEqual(repos, ['https://chat.openshift.io 8j366ft5affy3p36987cip'])
 
         backend = backend_sections[18]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'mattermost:group2')
         self.assertEqual(repos, ['https://chat.openshift.io 8j366ft5affy3p36987ciop'])
 
         backend = backend_sections[19]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'mbox')
         self.assertEqual(repos, ['metrics-grimoire ~/.perceval/mbox'])
 
         backend = backend_sections[20]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'mediawiki')
         self.assertEqual(repos, ['https://wiki.mozilla.org'])
 
         backend = backend_sections[21]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'meetup')
         self.assertEqual(repos, ['South-East-Puppet-User-Group'])
 
         backend = backend_sections[22]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'mozillaclub')
         self.assertEqual(repos,
                          ['https://spreadsheets.google.com/feeds/cells/'
                           '1QHl2bjBhMslyFzR5XXPzMLdzzx7oeSKTbgR5PM8qp64/ohaibtm/public/values?alt=json'])
 
         backend = backend_sections[23]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'nntp')
         self.assertEqual(repos, ['news.mozilla.org mozilla.dev.project-link'])
 
         backend = backend_sections[24]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'phabricator')
         self.assertEqual(repos, ['https://phabricator.wikimedia.org'])
 
         backend = backend_sections[25]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'pipermail')
         self.assertEqual(repos, ['https://mail.gnome.org/archives/libart-hackers/'])
 
         backend = backend_sections[26]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'puppetforge')
         self.assertEqual(repos, [''])
 
         backend = backend_sections[27]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'redmine')
         self.assertEqual(repos, ['http://tracker.ceph.com/'])
 
         backend = backend_sections[28]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'remo')
         self.assertEqual(repos, ['https://reps.mozilla.org'])
 
         backend = backend_sections[29]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'remo:activities')
         self.assertEqual(repos, ['https://reps.mozilla.org'])
 
         backend = backend_sections[30]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'rss')
         self.assertEqual(repos, ['https://blog.bitergia.com/feed/'])
 
         backend = backend_sections[31]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'slack')
         self.assertEqual(repos, ['C7LSGB0AU'])
 
         backend = backend_sections[32]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'stackexchange')
         self.assertEqual(repos,
                          ["https://stackoverflow.com/questions/tagged/ovirt",
@@ -279,18 +282,18 @@ class TestTaskProjects(unittest.TestCase):
                           "https://stackoverflow.com/questions/tagged/kibana"])
 
         backend = backend_sections[33]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'supybot')
         self.assertEqual(repos,
                          ['openshift ~/.perceval/irc/percevalbot/logs/ChannelLogger/freenode/#openshift/'])
 
         backend = backend_sections[34]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'telegram')
         self.assertEqual(repos, ['Mozilla_analytics'])
 
         backend = backend_sections[35]
-        repos = task.get_repos_by_backend_section(backend)
+        repos = task.get_repos_by_backend_section(global_data_sources, backend)
         self.assertEqual(backend, 'twitter')
         self.assertEqual(repos, ['bitergia'])
 


### PR DESCRIPTION
This PR allows to set up the global data source from the setup.cfg using the param `global_data_sources` in the `general` section. By default the global data sources are: bugzilla, bugzillarest, confluence, discourse, gerrit, jenkins, jira. 
Test and the related code has been changed accordingly.
