### PR TITLE
[mordred] Remove global data sources param

### DIFF
--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -168,13 +168,6 @@ class Config():
                     "default": MENU_YAML,
                     "type": str,
                     "description": "YAML file to define the menus to be shown in Kibiter"
-                },
-                "global_data_sources": {
-                    "optional": True,
-                    "default": GLOBAL_DATA_SOURCES,
-                    "type": list,
-                    "description": "List of data sources collected globally, they are declared in the "
-                                   "section 'unknown' of the projects.json"
                 }
             }
         }
@@ -665,12 +658,6 @@ class Config():
                    "enrich_pull_requests")
 
         return studies
-
-    def get_global_data_sources(self):
-        """Data sources that are collected globally, they are declared
-        in the section 'unknown' of the projects.json"""
-
-        return self.conf['general']['global_data_sources']
 
     def get_data_sources(self):
         data_sources = []

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -237,8 +237,7 @@ class Task():
         clean = False
 
         from .task_projects import TaskProjects
-        global_data_sources = self.config.get_global_data_sources()
-        repos = TaskProjects.get_repos_by_backend_section(global_data_sources, self.backend_section)
+        repos = TaskProjects.get_repos_by_backend_section(self.backend_section)
         if len(repos) == 1:
             # Support for filter raw when we have one repo
             (filter_raw, filters_raw_prefix) = self.__filters_raw(repos[0])

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -96,8 +96,7 @@ class TaskRawDataCollection(Task):
             fetch_archive = True
 
         # repos could change between executions because changes in projects
-        global_data_sources = self.config.get_global_data_sources()
-        repos = TaskProjects.get_repos_by_backend_section(global_data_sources, self.backend_section)
+        repos = TaskProjects.get_repos_by_backend_section(self.backend_section)
 
         if not repos:
             logger.warning("No collect repositories for %s", self.backend_section)
@@ -393,8 +392,7 @@ class TaskRawDataArthurCollection(Task):
             fetch_archive = True
 
         # repos could change between executions because changes in projects
-        global_data_sources = self.config.get_global_data_sources()
-        repos = TaskProjects.get_repos_by_backend_section(global_data_sources, self.backend_section)
+        repos = TaskProjects.get_repos_by_backend_section(self.backend_section)
 
         if not repos:
             logger.warning("No collect repositories for %s", self.backend_section)

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -136,8 +136,7 @@ class TaskEnrich(Task):
         only_identities = False
 
         # repos could change between executions because changes in projects
-        global_data_sources = self.config.get_global_data_sources()
-        repos = TaskProjects.get_repos_by_backend_section(global_data_sources, self.backend_section)
+        repos = TaskProjects.get_repos_by_backend_section(self.backend_section, raw=False)
 
         if not repos:
             logger.warning("No enrich repositories for %s", self.backend_section)

--- a/sirmordred/task_projects.py
+++ b/sirmordred/task_projects.py
@@ -68,22 +68,28 @@ class TaskProjects(Task):
         return cls.projects_last_diff
 
     @classmethod
-    def get_repos_by_backend_section(cls, global_data_sources, backend_section):
+    def get_repos_by_backend_section(cls, backend_section, raw=True):
         """ return list with the repositories for a backend_section """
         repos = []
         projects = TaskProjects.get_projects()
 
         for pro in projects:
             if backend_section in projects[pro]:
-                backend = Task.get_backend(backend_section)
-                if backend in global_data_sources and cls.GLOBAL_PROJECT in projects \
-                        and pro != cls.GLOBAL_PROJECT:
-                    logger.debug("Skip global data source %s for project %s",
-                                 backend, pro)
-                else:
+                if cls.GLOBAL_PROJECT not in projects:
                     repos += projects[pro][backend_section]
+                else:
+                    if pro == cls.GLOBAL_PROJECT:
+                        continue
 
-        logger.debug("List of repos for %s: %s", backend_section, repos)
+                    if raw:
+                        if backend_section in projects[cls.GLOBAL_PROJECT]:
+                            repos += projects[cls.GLOBAL_PROJECT][backend_section]
+                        else:
+                            repos += projects[pro][backend_section]
+                    else:
+                        repos += projects[pro][backend_section]
+
+        logger.debug("List of repos for %s: %s (raw=%s)", backend_section, repos, raw)
 
         return repos
 

--- a/sirmordred/task_track.py
+++ b/sirmordred/task_track.py
@@ -54,8 +54,7 @@ class TaskTrackItems(Task):
         # We need to track the items in all git repositories from OPNFV
         git_repos = []
 
-        global_data_sources = self.config.get_global_data_sources()
-        repos_raw = TaskProjects.get_repos_by_backend_section(global_data_sources, "git")
+        repos_raw = TaskProjects.get_repos_by_backend_section("git")
 
         # git://git.opnfv.org/apex -> https://git.opnfv.org/apex/plain/UPSTREAM
         for repo in repos_raw:

--- a/tests/test_task_projects.py
+++ b/tests/test_task_projects.py
@@ -106,49 +106,47 @@ class TestTaskProjects(unittest.TestCase):
         backend_sections.sort()
         backend = backend_sections[0]
 
-        global_data_sources = config.get_global_data_sources()
-
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'askbot')
         self.assertEqual(repos, ['https://ask.puppet.com'])
 
         backend = backend_sections[1]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'bugzilla')
         self.assertEqual(repos, ['https://bugs.eclipse.org/bugs/'])
 
         backend = backend_sections[2]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'bugzillarest')
         self.assertEqual(repos, ['https://bugzilla.mozilla.org'])
 
         backend = backend_sections[3]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'confluence')
         self.assertEqual(repos, ['https://wiki.open-o.org/'])
 
         backend = backend_sections[4]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'discourse')
         self.assertEqual(repos, ['https://foro.mozilla-hispano.org/'])
 
         backend = backend_sections[5]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'dockerhub')
         self.assertEqual(repos, ['bitergia kibiter'])
 
         backend = backend_sections[6]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'functest')
         self.assertEqual(repos, ['http://testresults.opnfv.org/test/'])
 
         backend = backend_sections[7]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'gerrit')
         self.assertEqual(repos, ['review.openstack.org'])
 
         backend = backend_sections[8]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'git')
         self.assertEqual(repos,
                          ["https://github.com/VizGrimoire/GrimoireLib "
@@ -156,125 +154,125 @@ class TestTaskProjects(unittest.TestCase):
                           "https://github.com/MetricsGrimoire/CMetrics"])
 
         backend = backend_sections[9]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'github')
         self.assertEqual(repos, ['https://github.com/grimoirelab/perceval'])
 
         backend = backend_sections[10]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'github:pull')
         self.assertEqual(repos, ['https://github.com/grimoirelab/perceval'])
 
         backend = backend_sections[11]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'gitlab')
         self.assertEqual(repos, ['https://gitlab.com/inkscape/inkscape-web'])
 
         backend = backend_sections[12]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'google_hits')
         self.assertEqual(repos, ['bitergia grimoirelab'])
 
         backend = backend_sections[13]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'hyperkitty')
         self.assertEqual(repos,
                          ['https://lists.mailman3.org/archives/list/mailman-users@mailman3.org'])
 
         backend = backend_sections[14]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'jenkins')
         self.assertEqual(repos, ['https://build.opnfv.org/ci'])
 
         backend = backend_sections[15]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'jira')
         self.assertEqual(repos, ['https://jira.opnfv.org'])
 
         backend = backend_sections[16]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'mattermost')
         self.assertEqual(repos, ['https://chat.openshift.io 8j366ft5affy3p36987pcugaoa'])
 
         backend = backend_sections[17]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'mattermost:group1')
         self.assertEqual(repos, ['https://chat.openshift.io 8j366ft5affy3p36987cip'])
 
         backend = backend_sections[18]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'mattermost:group2')
         self.assertEqual(repos, ['https://chat.openshift.io 8j366ft5affy3p36987ciop'])
 
         backend = backend_sections[19]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'mbox')
         self.assertEqual(repos, ['metrics-grimoire ~/.perceval/mbox'])
 
         backend = backend_sections[20]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'mediawiki')
         self.assertEqual(repos, ['https://wiki.mozilla.org'])
 
         backend = backend_sections[21]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'meetup')
         self.assertEqual(repos, ['South-East-Puppet-User-Group'])
 
         backend = backend_sections[22]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'mozillaclub')
         self.assertEqual(repos,
                          ['https://spreadsheets.google.com/feeds/cells/'
                           '1QHl2bjBhMslyFzR5XXPzMLdzzx7oeSKTbgR5PM8qp64/ohaibtm/public/values?alt=json'])
 
         backend = backend_sections[23]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'nntp')
         self.assertEqual(repos, ['news.mozilla.org mozilla.dev.project-link'])
 
         backend = backend_sections[24]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'phabricator')
         self.assertEqual(repos, ['https://phabricator.wikimedia.org'])
 
         backend = backend_sections[25]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'pipermail')
         self.assertEqual(repos, ['https://mail.gnome.org/archives/libart-hackers/'])
 
         backend = backend_sections[26]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'puppetforge')
         self.assertEqual(repos, [''])
 
         backend = backend_sections[27]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'redmine')
         self.assertEqual(repos, ['http://tracker.ceph.com/'])
 
         backend = backend_sections[28]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'remo')
         self.assertEqual(repos, ['https://reps.mozilla.org'])
 
         backend = backend_sections[29]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'remo:activities')
         self.assertEqual(repos, ['https://reps.mozilla.org'])
 
         backend = backend_sections[30]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'rss')
         self.assertEqual(repos, ['https://blog.bitergia.com/feed/'])
 
         backend = backend_sections[31]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'slack')
         self.assertEqual(repos, ['C7LSGB0AU'])
 
         backend = backend_sections[32]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'stackexchange')
         self.assertEqual(repos,
                          ["https://stackoverflow.com/questions/tagged/ovirt",
@@ -282,18 +280,18 @@ class TestTaskProjects(unittest.TestCase):
                           "https://stackoverflow.com/questions/tagged/kibana"])
 
         backend = backend_sections[33]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'supybot')
         self.assertEqual(repos,
                          ['openshift ~/.perceval/irc/percevalbot/logs/ChannelLogger/freenode/#openshift/'])
 
         backend = backend_sections[34]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'telegram')
         self.assertEqual(repos, ['Mozilla_analytics'])
 
         backend = backend_sections[35]
-        repos = task.get_repos_by_backend_section(global_data_sources, backend)
+        repos = task.get_repos_by_backend_section(backend)
         self.assertEqual(backend, 'twitter')
         self.assertEqual(repos, ['bitergia'])
 


### PR DESCRIPTION
This PR is an attempt to address the comments at https://github.com/chaoss/grimoirelab-sirmordred/pull/269. Thus this code removes the global data sources parameter, which is now automatically assessed based on the projects.json. In a nutshell, if a given data source appears in the section `unknown` of the projects.json and in another section, that data source is considered global. Thus, meaning that the all data is collected but just a portion of it is finally enriched.