### PR TITLE
[config] Fix flake8 error

### DIFF
--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -744,8 +744,8 @@ class Config():
                 elif val.lower() in ['true', 'false']:
                     typed_conf[s][option] = True if val.lower() == 'true' else False
                 # Check None
-                elif val.lower() is 'none':
-                    typed_conf[s][option] = None
+                elif val.lower() == 'none':
+                    typed_conf[s][option] = ''
                 else:
                     try:
                         # Check int


### PR DESCRIPTION
This code fixes the flake8 F632 error, which occurs when comparing str, bytes, and int literals with operators different from ==/!=.