### PR TITLE
[sirmordred] Enforce data retention policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ SirMordred is the tool used to coordinate the execution of the GrimoireLab platf
  * **aliases_file** (str: ./aliases.json): JSON file to define aliases for raw and enriched indexes
  * **menu_file** (str: ./menu.yaml): YAML file to define the menus to be shown in Kibiter
  * **global_data_sources** (list: bugzilla, bugzillarest, confluence, discourse, gerrit, jenkins, jira): List of data sources collected globally, they are declared in the section 'unknown' of the projects.json
+ * **retention_hours** (int: None): the maximum number of hours wrt the current date to retain the data
 ### [panels] 
 
  * **community** (bool: True): Include community section in dashboard

--- a/doc/config.md
+++ b/doc/config.md
@@ -35,6 +35,7 @@ Use python mordred/config.py to generate it.
  * **aliases_file** (str: ./aliases.json): JSON file to define aliases for raw and enriched indexes
  * **menu_file** (str: ./menu.yaml): YAML file to define the menus to be shown in Kibiter
  * **global_data_sources** (list: bugzilla, bugzillarest, confluence, discourse, gerrit, jenkins, jira): List of data sources collected globally, they are declared in the section 'unknown' of the projects.json
+ * **retention_hours** (int: None): the maximum number of hours wrt the current date to retain the data
 ### [panels] 
 
  * **community** (bool: True): Include community section in dashboard

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -168,6 +168,12 @@ class Config():
                     "default": MENU_YAML,
                     "type": str,
                     "description": "YAML file to define the menus to be shown in Kibiter"
+                },
+                "retention_hours": {
+                    "optional": True,
+                    "default": None,
+                    "type": int,
+                    "description": "The maximum number of hours wrt the current date to retain the data"
                 }
             }
         }

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -707,7 +707,8 @@ class Config():
                 else:
                     ptype = type(config[section][param])
                     ptype_ok = check_params[section][param]["type"]
-                    if ptype != ptype_ok:
+                    ptype_default = check_params[section][param]["default"]
+                    if ptype != ptype_ok and ptype_default is not None:
                         msg = "Wrong type for section param: %s %s %s should be %s" % \
                               (section, param, ptype, ptype_ok)
                         raise RuntimeError(msg)

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -252,3 +252,8 @@ class Task():
             logger.error("Error retrieving Elasticsearch version: " + url)
             raise
         return major
+
+    @staticmethod
+    def retain_data(hours_to_retain, es_url, index):
+        elastic = get_elastic(es_url, index)
+        elastic.delete_items(hours_to_retain)

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -142,6 +142,10 @@ class TaskRawDataCollection(Task):
         print("Collection for {}: finished after {} hours".format(self.backend_section,
                                                                   spent_time))
 
+        self.retain_data(cfg['general']['retention_hours'],
+                         self.conf['es_collection']['url'],
+                         self.conf[self.backend_section]['raw_index'])
+
 
 class TaskRawDataArthurCollection(Task):
     """ Basic class to control arthur for data collection """

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -287,7 +287,7 @@ class TaskEnrich(Task):
 
         self.__autorefresh(aoc_backend, studies=True)
 
-    def __studies(self):
+    def __studies(self, retention_hours):
         """ Execute the studies configured for the current backend """
 
         cfg = self.config.get_conf()
@@ -328,7 +328,7 @@ class TaskEnrich(Task):
 
         studies_args = self.__load_studies()
 
-        do_studies(ocean_backend, enrich_backend, studies_args)
+        do_studies(ocean_backend, enrich_backend, studies_args, retention_hours=retention_hours)
         # Return studies to its original value
         enrich_backend.studies = all_studies
 
@@ -360,6 +360,11 @@ class TaskEnrich(Task):
         try:
             self.__enrich_items()
 
+            retention_hours = cfg['general']['retention_hours']
+            self.retain_data(retention_hours,
+                             self.conf['es_enrichment']['url'],
+                             self.conf[self.backend_section]['enriched_index'])
+
             autorefresh = cfg['es_enrichment']['autorefresh']
 
             if autorefresh:
@@ -368,7 +373,7 @@ class TaskEnrich(Task):
             else:
                 logger.debug("Not doing autorefresh for %s", self.backend_section)
 
-            self.__studies()
+            self.__studies(retention_hours)
 
             if autorefresh:
                 self.__autorefresh_studies(cfg)


### PR DESCRIPTION
This PR allows to remove the data from raw, enriched and studies indexes based on the new config param `retention_horus`. In a nutshell, the attribute allows to declare the maximum number of hours after which the data must be removed from the platform. After the end of the collection and enrichment phases, a `delete_by_query` operation is triggered on the target index.