### PR TITLE
[mordred] Handle filter raw in task and task-collection

### DIFF
--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -204,32 +204,6 @@ class Task():
 
         return enrich_backend
 
-    def __filters_raw(self, repo):
-        """ Get the filters raw for a repository """
-        p2o_args = self._compose_p2o_params(self.backend_section, repo)
-        filter_raw = p2o_args['filter-raw'] if 'filter-raw' in p2o_args else None
-        filters_raw_prefix = p2o_args['filters-raw-prefix'] if 'filters-raw-prefix' in p2o_args else None
-
-        # filter_raw must be converted from the string param to a dict
-        filter_raw_dict = {}
-        if filter_raw:
-            filter_raw_dict['name'] = filter_raw.split(":")[0].replace('"', '')
-            filter_raw_dict['value'] = filter_raw.split(":")[1].replace('"', '')
-        # filters_raw_prefix must be converted from the list param to
-        # DSL query format for a should filter inside a boolean filter
-        filter_raw_should = None
-        if filters_raw_prefix:
-            filter_raw_should = {"should": []}
-            for filter_prefix in filters_raw_prefix:
-                fname = filter_prefix.split(":")[0].replace('"', '')
-                fvalue = filter_prefix.split(":")[1].replace('"', '')
-                filter_raw_should["should"].append(
-                    {
-                        "prefix": {fname: fvalue}
-                    }
-                )
-        return (filter_raw_dict, filter_raw_should)
-
     def _get_ocean_backend(self, enrich_backend):
         backend_cmd = None
 
@@ -240,7 +214,11 @@ class Task():
         repos = TaskProjects.get_repos_by_backend_section(self.backend_section)
         if len(repos) == 1:
             # Support for filter raw when we have one repo
-            (filter_raw, filters_raw_prefix) = self.__filters_raw(repos[0])
+            repo = repos[0]
+            p2o_args = self._compose_p2o_params(self.backend_section, repo)
+            filter_raw = p2o_args['filter-raw'] if 'filter-raw' in p2o_args else None
+            filters_raw_prefix = p2o_args['filter-raw-prefix'] if 'filter-raw-prefix' in p2o_args else None
+
             if filter_raw or filters_raw_prefix:
                 logger.info("Using %s %s for getting identities from raw",
                             filter_raw, filters_raw_prefix)

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -106,8 +106,10 @@ class TaskRawDataCollection(Task):
             filter_raw = p2o_args['filter-raw'] if 'filter-raw' in p2o_args else None
 
             if filter_raw:
-                # If filter-raw exists the goal is to enrich already collected
-                # data, so don't collect anything
+                # If filter-raw exists it means that there is an equivalent URL
+                # in the `unknown` section of the projects.json. Thus the URL with
+                # filter-raw is ignored in the collection phase, while the URL
+                # in `unknown` is considered in this phase.
                 logging.warning("Not collecting filter raw repository: %s", repo)
                 continue
 
@@ -405,8 +407,10 @@ class TaskRawDataArthurCollection(Task):
                 p2o_args = self._compose_p2o_params(self.backend_section, repo)
                 filter_raw = p2o_args['filter-raw'] if 'filter-raw' in p2o_args else None
                 if filter_raw:
-                    # If filter-raw exists the goal is to enrich already collected
-                    # data, so don't collect anything
+                    # If filter-raw exists it means that there is an equivalent URL
+                    # in the `unknown` section of the projects.json. Thus the URL with
+                    # filter-raw is ignored in the collection phase, while the URL
+                    # in `unknown` is considered in this phase.
                     logging.warning("Not collecting filter raw repository: %s", repo)
                     continue
                 backend_args = self._compose_perceval_params(self.backend_section, repo)


### PR DESCRIPTION
This code refactors the logic to process the filter-raw, plus it also adds some documentation to better explain why url with filter-raw are ignored during the collection phase.

Note that the code at: https://github.com/chaoss/grimoirelab-sirmordred/compare/master...valeriocos:filter-raw-ref?expand=1#diff-acf081d06eea60ca1f99f5361dba311bL207 smells bad. 

Let's suppose we have the following conf:
```
"grimoire": {
        "git": [
            "https://github.com/chaoss/grimoirelab-elk --filter-raw=data.files.action:M"
        ],
"unknown": {
        "git": [
            "https://github.com/chaoss/grimoirelab-elk"
        ],

[git]
raw_index = git_chaoss_x
enriched_index = git_chaoss_x_enriched_y
latest-items = true
studies = [enrich_onion]
```

In this case, the filters are ignored because the method [get_repos_by_backend_section](https://github.com/chaoss/grimoirelab-sirmordred/compare/master...valeriocos:filter-raw-ref?expand=1#diff-acf081d06eea60ca1f99f5361dba311bL240), will return the URL defined in `unknown`. Conversely, if the `unknown` section is not present in the `projects.json`, the collection phase will ignore the URL defined under `grimoire` (because contains the filter-raw param) and thus the enriched phase won't work because the raw index is not created. Thus, it seems that code could work only when the `filter-raw-prefix` is set, however in this case is unclear to me why the condition at: https://github.com/chaoss/grimoirelab-sirmordred/compare/master...valeriocos:filter-raw-ref?expand=1#diff-acf081d06eea60ca1f99f5361dba311bR222 checks both raw-filter and raw-filter-prefix

