### PR TITLE
[task_projects] Refactor `get_repos_by_backend_section`

### DIFF
--- a/sirmordred/task_projects.py
+++ b/sirmordred/task_projects.py
@@ -75,21 +75,51 @@ class TaskProjects(Task):
 
         for pro in projects:
             if backend_section in projects[pro]:
+                # if the projects.json doesn't contain the `unknown` project, add the repos in the bck section
                 if cls.GLOBAL_PROJECT not in projects:
                     repos += projects[pro][backend_section]
                 else:
-                    if pro == cls.GLOBAL_PROJECT:
-                        continue
-
+                    # if the projects.json contains the `unknown` project
+                    # in the case of the collection phase
                     if raw:
-                        if backend_section in projects[cls.GLOBAL_PROJECT]:
-                            repos += projects[cls.GLOBAL_PROJECT][backend_section]
+                        # if the current project is not `unknown`
+                        if pro != cls.GLOBAL_PROJECT:
+                            # if the bck section is not in the `unknown` project, add the repos in the bck section
+                            if backend_section not in projects[cls.GLOBAL_PROJECT]:
+                                repos += projects[pro][backend_section]
+                            # if the backend section is in the `unknown` project,
+                            # add the repo in the bck section under `unknown`
+                            elif backend_section in projects[pro] and backend_section in projects[cls.GLOBAL_PROJECT]:
+                                repos += projects[cls.GLOBAL_PROJECT][backend_section]
+                        # if the current project is `unknown`
                         else:
-                            repos += projects[pro][backend_section]
+                            # if the backend section is only in the `unknown` project,
+                            # add the repo in the bck section under `unknown`
+                            not_in_unknown = [projects[pro] for pro in projects if pro != cls.GLOBAL_PROJECT][0]
+                            if backend_section not in not_in_unknown:
+                                repos += projects[cls.GLOBAL_PROJECT][backend_section]
+                    # in the case of the enrichment phase
                     else:
-                        repos += projects[pro][backend_section]
+                        # if the current project is not `unknown`
+                        if pro != cls.GLOBAL_PROJECT:
+                            # if the bck section is not in the `unknown` project, add the repos in the bck section
+                            if backend_section not in projects[cls.GLOBAL_PROJECT]:
+                                repos += projects[pro][backend_section]
+                            # if the backend section is in the `unknown` project, add the repos in the bck section
+                            elif backend_section in projects[pro] and backend_section in projects[cls.GLOBAL_PROJECT]:
+                                repos += projects[pro][backend_section]
+                        # if the current project is `unknown`
+                        else:
+                            # if the backend section is only in the `unknown` project,
+                            # add the repo in the bck section under `unknown`
+                            not_in_unknown = [projects[pro] for pro in projects if pro != cls.GLOBAL_PROJECT][0]
+                            if backend_section not in not_in_unknown:
+                                repos += projects[pro][backend_section]
 
         logger.debug("List of repos for %s: %s (raw=%s)", backend_section, repos, raw)
+
+        # avoid duplicated repos
+        repos = list(set(repos))
 
         return repos
 

--- a/tests/test-repos-projects.json
+++ b/tests/test-repos-projects.json
@@ -1,0 +1,22 @@
+{
+    "grimoire": {
+        "gerrit:onos": [
+            "gerrit.onosproject.org --filter-raw=data.project:OnosSystemTest",
+            "gerrit.onosproject.org --filter-raw=data.project:OnosSystemTestJenkins",
+            "gerrit.onosproject.org --filter-raw=data.project:cord-openwrt",
+            "gerrit.onosproject.org --filter-raw=data.project:fabric-control",
+            "gerrit.onosproject.org --filter-raw=data.project:manifest"
+        ],
+        "git": [
+            "https://github.com/chaoss/grimoirelab-perceval"
+        ]
+    },
+    "unknown": {
+        "gerrit:onos": [
+            "gerrit.onosproject.org"
+        ],
+        "bugzillarest": [
+            "https://bugzilla.mozilla.org"
+        ]
+    }
+}

--- a/tests/test-repos.cfg
+++ b/tests/test-repos.cfg
@@ -1,0 +1,86 @@
+#
+# Test config with only git and github activated
+#
+
+
+# Config values format
+#
+# List: [val1, val2 ...]
+# Int: int_value
+# Int as string: "Int"
+# List as string: "[val1, val2 ...]"
+# String: string_value
+# None: None, none
+# Boolean: true, True, False, false
+
+[general]
+short_name = Grimoire
+update = false
+min_update_delay = 10
+debug = true
+# /var/log/mordred/
+logs_dir = logs
+# Number of items per bulk request to Elasticsearch
+bulk_size = 100
+# Number of items to get from Elasticsearch when scrolling
+scroll_size = 100
+
+[projects]
+projects_file = ./test-repos-projects.json
+
+[es_collection]
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
+
+[es_enrichment]
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
+
+[sortinghat]
+host = 127.0.0.1
+user = root
+password =
+database = test_sh
+load_orgs = true
+orgs_file = data/orgs_sortinghat.json
+identities_api_token = 'xxxx'
+identities_file = [data/perceval_identities_sortinghat.json]
+affiliate = true
+# commonly: Unknown
+unaffiliated_group = Unknown
+autoprofile = [customer,git,github]
+matching = [email]
+sleep_for = 120
+# sleep_for = 1800
+bots_names = [Beloved Bot]
+
+[panels]
+kibiter_time_from= "now-30y"
+kibiter_default_index= "gitlab"
+kibiter_url = http://localhost:5601
+community = true
+gitlab-issues = true
+gitlab-merges = true
+
+[phases]
+collection = true
+identities = true
+enrichment = true
+panels = true
+
+[git]
+raw_index = git_chaoss_180804
+enriched_index = git_chaoss_180804_enriched_180804
+latest-items = true
+category = commit
+
+[bugzillarest]
+raw_index = bugzillarest_mozilla_180411
+enriched_index = bugzillarest_mozilla_180411_enriched_181024
+no-archive = true
+
+[gerrit:onos]
+user = owlbot
+no-archive = true
+raw_index = gerrit_onf_190109
+enriched_index = gerrit_onf_190109_enriched_190218


### PR DESCRIPTION
This PR refactors the method `get_repos_by_backend_section` in
order to support the following actions:
- collect the raw data when a repo is only declared in the `unknown`
section
- enrich the data when a repo is only declared in the `unknown`
section