### PR TITLE
[mordred] support finosmeetings data

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -30,6 +30,10 @@
       "raw": ["dockerhub-raw"],
       "enrich": ["dockerhub"]
   },
+  "finosmeetings": {
+      "raw": ["finosmeetings-raw"],
+      "enrich": ["finosmeetings", "affiliations"]
+  },
   "functest": {
       "raw": ["functest-raw"],
       "enrich": ["functest"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ redis
 -e git+https://github.com/chaoss/grimoirelab-perceval-puppet/#egg=grimoirelab-perceval-puppet
 -e git+https://github.com/chaoss/grimoirelab-perceval-opnfv/#egg=grimoirelab-perceval-opnfv
 -e git+https://github.com/chaoss/grimoirelab-perceval-mozilla/#egg=grimoirelab-perceval-mozilla
+-e git+https://github.com/Bitergia/grimoirelab-perceval-finos/#egg=grimoirelab-perceval-finos
 -e git+https://github.com/chaoss/grimoirelab-kingarthur/#egg=grimoirelab-kingarthur


### PR DESCRIPTION
This code includes the repo https://github.com/Bitergia/grimoirelab-perceval-finos to the requirements.txt file. Furthermore, it also updates the aliases.json to include the aliases for the raw and enriched indexes of finosmeetings data.