### PR TITLE
[task_enrich] Support retain identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ SirMordred is the tool used to coordinate the execution of the GrimoireLab platf
  * **aliases_file** (str: ./aliases.json): JSON file to define aliases for raw and enriched indexes
  * **menu_file** (str: ./menu.yaml): YAML file to define the menus to be shown in Kibiter
  * **global_data_sources** (list: bugzilla, bugzillarest, confluence, discourse, gerrit, jenkins, jira): List of data sources collected globally, they are declared in the section 'unknown' of the projects.json
- * **retention_hours** (int: None): the maximum number of hours wrt the current date to retain the data
+ * **retention_time** (int: None): the maximum number of minutes wrt the current date to retain the data
 ### [panels] 
 
  * **community** (bool: True): Include community section in dashboard

--- a/doc/config.md
+++ b/doc/config.md
@@ -35,7 +35,7 @@ Use python mordred/config.py to generate it.
  * **aliases_file** (str: ./aliases.json): JSON file to define aliases for raw and enriched indexes
  * **menu_file** (str: ./menu.yaml): YAML file to define the menus to be shown in Kibiter
  * **global_data_sources** (list: bugzilla, bugzillarest, confluence, discourse, gerrit, jenkins, jira): List of data sources collected globally, they are declared in the section 'unknown' of the projects.json
- * **retention_hours** (int: None): the maximum number of hours wrt the current date to retain the data
+ * **retention_time** (int: None): the maximum number of minutes wrt the current date to retain the data
 ### [panels] 
 
  * **community** (bool: True): Include community section in dashboard

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -671,6 +671,17 @@ class Config():
 
         return studies
 
+    def get_active_data_sources(self):
+        data_sources = []
+        backend_sections = self.get_backend_sections()
+
+        for section in self.conf.keys():
+            data_source = section.split(":")[0]
+            if data_source in backend_sections:
+                data_sources.append(data_source)
+
+        return data_sources
+
     def get_data_sources(self):
         data_sources = []
         backend_sections = self.get_backend_sections()

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -169,11 +169,11 @@ class Config():
                     "type": str,
                     "description": "YAML file to define the menus to be shown in Kibiter"
                 },
-                "retention_hours": {
+                "retention_time": {
                     "optional": True,
                     "default": None,
                     "type": int,
-                    "description": "The maximum number of hours wrt the current date to retain the data"
+                    "description": "The maximum number of minutes wrt the current date to retain the data"
                 }
             }
         }

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -254,6 +254,6 @@ class Task():
         return major
 
     @staticmethod
-    def retain_data(hours_to_retain, es_url, index):
+    def retain_data(retention_time, es_url, index):
         elastic = get_elastic(es_url, index)
-        elastic.delete_items(hours_to_retain)
+        elastic.delete_items(retention_time)

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -142,7 +142,7 @@ class TaskRawDataCollection(Task):
         print("Collection for {}: finished after {} hours".format(self.backend_section,
                                                                   spent_time))
 
-        self.retain_data(cfg['general']['retention_hours'],
+        self.retain_data(cfg['general']['retention_time'],
                          self.conf['es_collection']['url'],
                          self.conf[self.backend_section]['raw_index'])
 


### PR DESCRIPTION
This code allows to retain only the identities that have been seen after a give date (defined in terms of minutes wrt to the current time, `retention_time`).