### PR TITLE
Upload jenkins export and github repos panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ SirMordred is the tool used to coordinate the execution of the GrimoireLab platf
  * **kibiter_url** (str): Kibiter URL (**Required**)
  * **kibiter_version** (str: None): Kibiter version
  * **kafka** (bool: False): Include KIP section in dashboard
+ * **github-repos** (bool: False): Enable GitHub repo stats menu
  * **gitlab-issues** (bool: False): Enable GitLab issues menu
  * **gitlab-merges** (bool: False): Enable GitLab merge requests menu
  * **mattermost** (bool: False): Enable Mattermost menu
  * **strict** (bool: True): Enable strict panels loading
- 
-### [phases] 
+### [phases]
 
  * **collection** (bool: True): Activate collection of items (**Required**)
  * **enrichment** (bool: True): Activate enrichment of items (**Required**)

--- a/aliases.json
+++ b/aliases.json
@@ -46,6 +46,10 @@
       "raw": ["git-raw"],
       "enrich": ["git", "git_author", "git_enrich", "affiliations"]
   },
+  "github:repo": {
+      "raw": ["github_repositories-raw"],
+      "enrich": ["github_repositories"]
+  },
   "github": {
       "raw": ["github-raw"],
       "enrich": ["github_issues", "github_issues_enrich", "issues_closed",

--- a/doc/config.md
+++ b/doc/config.md
@@ -44,6 +44,7 @@ Use python mordred/config.py to generate it.
  * **kibiter_url** (str): Kibiter URL (**Required**)
  * **kibiter_version** (str: None): Kibiter version
  * **kafka** (bool: False): Include KIP section in dashboard
+ * **github-repos** (bool: False): Enable GitHub repo stats menu
  * **gitlab-issues** (bool: False): Enable GitLab issues menu
  * **gitlab-merges** (bool: False): Enable GitLab merge requests menu
  * **mattermost** (bool: False): Enable Mattermost menu

--- a/menu.yaml
+++ b/menu.yaml
@@ -252,6 +252,8 @@
     panel: panels/json/jenkins_nodes.json
   - name: Categories
     panel: panels/json/jenkins_job_categories.json
+  - name: Export
+    panel: panels/json/jenkins_export.json
 - name: Mozilla Club
   source: mozillaclub
   icon: default.png

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -367,6 +367,12 @@ class Config():
                     "type": bool,
                     "description": "Enable kafka menu"
                 },
+                "github-repos": {
+                    "optional": True,
+                    "default": False,
+                    "type": bool,
+                    "description": "Enable GitHub repo stats menu"
+                },
                 "gitlab-issues": {
                     "optional": True,
                     "default": False,

--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -88,6 +88,20 @@ COMMUNITY_MENU = {
     ]
 }
 
+GITHUB_REPOS = "github-repos"
+GITHUB_REPOS_PANEL_OVERALL = "panels/json/github_repositories.json"
+GITHUB_REPOS_IP = "panels/json/github_repositories-index-pattern.json"
+
+GITHUB_REPOS_MENU = {
+    'name': 'GitHub Repositories',
+    'source': GITHUB_REPOS,
+    'icon': 'default.png',
+    'index-patterns': [GITHUB_REPOS_IP],
+    'menu': [
+        {'name': 'Overview', 'panel': GITHUB_REPOS_PANEL_OVERALL}
+    ]
+}
+
 GITLAB_ISSUES = "gitlab-issues"
 GITLAB_ISSUES_PANEL_OVERALL = "panels/json/gitlab_issues.json"
 GITLAB_ISSUES_PANEL_BACKLOG = "panels/json/gitlab_issues_backlog.json"
@@ -192,6 +206,9 @@ class TaskPanels(Task):
 
         if self.conf['panels'][KAFKA]:
             self.panels[KAFKA] = [KAFKA_PANEL, KAKFA_IP]
+
+        if self.conf['panels'][GITHUB_REPOS]:
+            self.panels[GITHUB_REPOS] = [GITHUB_REPOS_PANEL_OVERALL, GITHUB_REPOS_IP]
 
         if self.conf['panels'][GITLAB_ISSUES]:
             self.panels[GITLAB_ISSUES] = [GITLAB_ISSUES_PANEL_BACKLOG, GITLAB_ISSUES_PANEL_OVERALL,
@@ -419,6 +436,9 @@ class TaskPanelsMenu(Task):
                 logger.error(ex)
                 raise
 
+        if self.conf['panels'][GITHUB_REPOS]:
+            self.panels_menu.append(GITHUB_REPOS_MENU)
+
         if self.conf['panels'][GITLAB_ISSUES]:
             self.panels_menu.append(GITLAB_ISSUES_MENU)
 
@@ -448,7 +468,8 @@ class TaskPanelsMenu(Task):
         active_ds = []
         for entry in self.panels_menu:
             ds = entry['source']
-            if ds in self.conf.keys() or ds in [COMMUNITY, KAFKA, GITLAB_ISSUES, GITLAB_MERGES, MATTERMOST]:
+            if ds in self.conf.keys() or ds in [COMMUNITY, KAFKA, GITLAB_ISSUES, GITLAB_MERGES,
+                                                MATTERMOST, GITHUB_REPOS]:
                 active_ds.append(ds)
         logger.debug("Active data sources for menu: %s", active_ds)
 

--- a/tests/aliases.json
+++ b/tests/aliases.json
@@ -47,6 +47,10 @@
       "enrich": ["github_issues", "github_issues_enrich", "issues_closed",
                  "issues_created", "issues_updated", "affiliations"]
   },
+  "github:repo": {
+      "raw": ["github_repositories-raw"],
+      "enrich": ["github_repositories"]
+  },
   "gitlab:issue": {
       "raw": ["gitlab_issue-raw"],
       "enrich": ["gitlab", "gitlab_issue", "affiliations"]


### PR DESCRIPTION
This PR allows to upload the jenkins export and github repos panels by setting the params `jenkins-export` and `github-repos` to true in the section `panels` of the setup.cfg. By default these params are disabled. Furthermore, the aliases.json file has been modified to include the aliases for the raw and enriched indexes related to the github repositories data 