### PR TITLE
[doc] Fix missing --cfg param for micro mordred example

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Micro Mordred is located in the [/utils](https://github.com/chaoss/grimoirelab-s
 Examples of possible executions are shown below:
 ```
 cd .../grimoirelab-sirmordred/utils/
-micro.py --raw --enrich ./setup.cfg --backends git #  execute the Raw and Enrich tasks for the Git cfg section
+micro.py --raw --enrich --cfg ./setup.cfg --backends git #  execute the Raw and Enrich tasks for the Git cfg section
 micro.py --panels # execute the Panels task to load the Sigils panels to Kibiter
 ``` 
 


### PR DESCRIPTION
This code fixes the first example to execute micro mordred which was missing the param `--cfg`.