### PR TITLE
[mordred] Pass repo url in projects.json to ELK

### DIFF
--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -127,7 +127,7 @@ class TaskRawDataCollection(Task):
             try:
                 feed_backend(es_col_url, clean, fetch_archive, backend, backend_args,
                              cfg[ds]['raw_index'], cfg[ds]['enriched_index'], project,
-                             es_aliases=es_aliases)
+                             es_aliases=es_aliases, projects_json_repo=repo)
             except Exception:
                 logger.error("Something went wrong collecting data from this %s repo: %s . "
                              "Using the backend_args: %s " % (ds, url, str(backend_args)))

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -202,7 +202,8 @@ class TaskEnrich(Task):
                                node_regex=node_regex,
                                studies_args=studies_args,
                                es_enrich_aliases=es_enrich_aliases,
-                               last_enrich_date=last_enrich_date)
+                               last_enrich_date=last_enrich_date,
+                               projects_json_repo=repo)
             except Exception as ex:
                 logger.error("Something went wrong producing enriched data for %s . "
                              "Using the backend_args: %s ", self.backend_section, str(backend_args))


### PR DESCRIPTION
This PR allows to forward the url of a specific repo within the projects.json to elk (`feed_backend` and `enrich_backend` functions). This change is needed to simplify the assignment of the repo to the project
defined in the projects.json. The functions `feed_backend` and `enrich_backend` now accepts a new param (set to None by default to not break existing functionalities) `projects_json_repo`. 