### PR TITLE
[config] Add study to process git branches

### DIFF
--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -667,7 +667,7 @@ class Config():
         # a study name could include and extra ":<param>"
         # to have several backend entries with different configs
         studies = ("enrich_demography", "enrich_areas_of_code", "enrich_onion", "kafka_kip",
-                   "enrich_pull_requests")
+                   "enrich_pull_requests", "enrich_git_branches")
 
         return studies
 

--- a/tests/test_studies.cfg
+++ b/tests/test_studies.cfg
@@ -70,7 +70,11 @@ panels = true
 [git]
 raw_index = ???
 enriched_index = ???
-studies = [enrich_demography:git, enrich_areas_of_code:git, enrich_onion:git]
+studies = [enrich_demography:git, enrich_areas_of_code:git,
+           enrich_onion:git, enrich_git_branches:git]
+
+[enrich_git_branches:git]
+# no params
 
 [enrich_demography:git]
 date_field = ???         # default: grimoire_creation_date


### PR DESCRIPTION
This PR adds a study to process git branches. It is activated by adding the section [enrich_git_branches]
in the setup.cfg, it doesn't require any param, and it applies to the enriched index.

An example of this study has been added to tests/test_studies.cfg 