### PR TITLE
[aliases.json] Rename alias for gitlab issues

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -56,8 +56,8 @@
                  "issues_created", "issues_updated", "affiliations"]
   },
   "gitlab:issue": {
-      "raw": ["gitlab_issue-raw"],
-      "enrich": ["gitlab", "gitlab_issue", "affiliations"]
+      "raw": ["gitlab_issues-raw"],
+      "enrich": ["gitlab", "gitlab_issues", "affiliations"]
   },
   "gitlab:merge": {
       "raw": ["gitlab_merge_requests-raw"],


### PR DESCRIPTION
This code updates the name of the alias used for gitlab issues, which now is `gitlab_issues`.