### PR TITLE
[alias] Remove gitlab alias

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -57,7 +57,7 @@
   },
   "gitlab:issue": {
       "raw": ["gitlab_issues-raw"],
-      "enrich": ["gitlab", "gitlab_issues", "affiliations"]
+      "enrich": ["gitlab_issues", "affiliations"]
   },
   "gitlab:merge": {
       "raw": ["gitlab_merge_requests-raw"],


### PR DESCRIPTION
`gitlab` alias is misleading, `gitlab_issues` is the right one.

Signed-off-by: Alberto Pérez García-Plaza <alpgarcia@bitergia.com>