### PR TITLE
[utils-micro] Add support to load identities in micro

### DIFF
--- a/utils/grimoirelab_valid.yml
+++ b/utils/grimoirelab_valid.yml
@@ -1,0 +1,42 @@
+- profile:
+    name: J. Manrique Lopez de la Fuente
+  enrollments:
+    - organization: Bitergia
+      start: 2013-01-01
+  github:
+    - jsmanrique
+  jira:
+    - jsm
+  email:
+    - jsmanrique@bitergia.com
+
+- profile:
+    name: Luis Cañas-Díaz
+  enrollments:
+    - organization: GSyC/LibreSoft
+      start: 2003-01-01
+      end: 2011-12-31
+    - organization: Bitergia
+      start: 2012-01-01T00:00:00
+    - organization: unknown
+  github:
+    - sanacl
+  irc:
+    - lcanas
+  email:
+    - lcanas@bitergia.com
+
+- profile:
+    name: Owl Bot
+    is_bot: true
+  email:
+    - owlbot@bitergia.com
+  enrollments:
+    - organization: Unknown
+      start: 2017-01-01T00:00:00
+
+- blacklist:
+    - no-reply@example.com
+    - root
+    - Generic Account
+    - valcos@bitergia.com


### PR DESCRIPTION
This code allows to load identities from micro-mordred. This can be achieved by using the param --identities-load. An example of identities file is also included. 