### PR TITLE
[mordred] Add repo labels support

### DIFF
--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -90,6 +90,20 @@ class Task():
     def set_backend_section(self, backend_section):
         self.backend_section = backend_section
 
+    def _extract_repo_labels(self, backend_section, repo):
+        """Extract the labels declared in the repositories within the projects.json, and remove them to
+        avoid breaking already existing functionalities.
+
+        :param backend_section: name of the backend section
+        :param repo: repo url in projects.json
+        """
+        backend = self.get_backend(backend_section)
+        connector = get_connector_from_name(backend)
+        ocean = connector[1]
+
+        processed_repo, labels_lst = ocean.extract_repo_labels(repo)
+        return processed_repo, labels_lst
+
     def _compose_p2o_params(self, backend_section, repo):
         # get p2o params included in the projects list
         params = {}
@@ -215,6 +229,7 @@ class Task():
         if len(repos) == 1:
             # Support for filter raw when we have one repo
             repo = repos[0]
+            repo, repo_labels = self._extract_repo_labels(self.backend_section, repo)
             p2o_args = self._compose_p2o_params(self.backend_section, repo)
             filter_raw = p2o_args['filter-raw'] if 'filter-raw' in p2o_args else None
             filters_raw_prefix = p2o_args['filter-raw-prefix'] if 'filter-raw-prefix' in p2o_args else None

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -102,6 +102,7 @@ class TaskRawDataCollection(Task):
             logger.warning("No collect repositories for %s", self.backend_section)
 
         for repo in repos:
+            repo, repo_labels = self._extract_repo_labels(self.backend_section, repo)
             p2o_args = self._compose_p2o_params(self.backend_section, repo)
             filter_raw = p2o_args['filter-raw'] if 'filter-raw' in p2o_args else None
 
@@ -127,7 +128,7 @@ class TaskRawDataCollection(Task):
             try:
                 feed_backend(es_col_url, clean, fetch_archive, backend, backend_args,
                              cfg[ds]['raw_index'], cfg[ds]['enriched_index'], project,
-                             es_aliases=es_aliases, projects_json_repo=repo)
+                             es_aliases=es_aliases, projects_json_repo=repo, repo_labels=repo_labels)
             except Exception:
                 logger.error("Something went wrong collecting data from this %s repo: %s . "
                              "Using the backend_args: %s " % (ds, url, str(backend_args)))
@@ -408,6 +409,7 @@ class TaskRawDataArthurCollection(Task):
             tag = self.backend_tag(repo)
             if tag not in self.arthur_items:
                 self.arthur_items[tag] = []
+                repo, repo_labels = self._extract_repo_labels(self.backend_section, repo)
                 p2o_args = self._compose_p2o_params(self.backend_section, repo)
                 filter_raw = p2o_args['filter-raw'] if 'filter-raw' in p2o_args else None
                 if filter_raw:

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -154,7 +154,7 @@ class TaskEnrich(Task):
             last_enrich_date = last_enrich_date.replace(second=0, microsecond=0, tzinfo=None)
 
         for repo in repos:
-            # First process p2o params from repo
+            repo, repo_labels = self._extract_repo_labels(self.backend_section, repo)
             p2o_args = self._compose_p2o_params(self.backend_section, repo)
             filter_raw = p2o_args['filter-raw'] if 'filter-raw' in p2o_args else None
             filters_raw_prefix = p2o_args['filter-raw-prefix'] if 'filter-raw-prefix' in p2o_args else None
@@ -203,7 +203,8 @@ class TaskEnrich(Task):
                                studies_args=studies_args,
                                es_enrich_aliases=es_enrich_aliases,
                                last_enrich_date=last_enrich_date,
-                               projects_json_repo=repo)
+                               projects_json_repo=repo,
+                               repo_labels=repo_labels)
             except Exception as ex:
                 logger.error("Something went wrong producing enriched data for %s . "
                              "Using the backend_args: %s ", self.backend_section, str(backend_args))


### PR DESCRIPTION
This code allows to add labels to the repositories, thus providing further classifications based on the customer needs. The labeling is achieved by adding `--labels=[a, b, c]` within the projects.json
lines (e.g., `https://github.com/chaoss/grimoirelab-perceval --labels=[collection]`).
It is worth noting that labels info are extracted from the projects.json and filtered when loading the projects.json in ELK in order to avoid breaking already existing functionalities.