### PR TITLE
[task_enrich] Fix elasticsearch.exceptions.SSLError: ConnectionError

### DIFF
--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -27,7 +27,7 @@ import time
 
 from datetime import datetime, timedelta
 
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, RequestsHttpConnection
 
 from grimoire_elk.elk import (do_studies,
                               enrich_backend,
@@ -282,8 +282,9 @@ class TaskEnrich(Task):
 
         logger.debug("Autorefresh for Areas of Code study index: %s", aoc_index)
 
-        es = Elasticsearch([self.conf['es_enrichment']['url']], timeout=100,
-                           verify_certs=self._get_enrich_backend().elastic.requests.verify)
+        es = Elasticsearch([self.conf['es_enrichment']['url']], timeout=100, retry_on_timeout=True,
+                           verify_certs=self._get_enrich_backend().elastic.requests.verify,
+                           connection_class=RequestsHttpConnection)
 
         if not es.indices.exists(index=aoc_index):
             logger.debug("Not doing autorefresh, index doesn't exist for Areas of Code study")


### PR DESCRIPTION
This PR updates the statement that initializes the Elasticsearch objects (imported from the library elasticsearch) to use RequestsHttpConnection as connection class, thus avoiding `elasticsearch.exceptions.SSLError: ConnectionError exceptions`
