### PR TITLE
[mordred] Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.pyc
+*.pyo
+build
+dist
+.project
+.pydevproject
+.settings
+__pycache__
+utils/projects.json
+utils/setup.cfg


### PR DESCRIPTION
This code adds the .gitignore file to mordred. In particular, it prevents to upload the setup.cfg and projects.json used by micro.py in utils/.