### PR TITLE
[task_collection] Return errors info for task collection

### DIFF
--- a/tests/test_task_collection.py
+++ b/tests/test_task_collection.py
@@ -97,7 +97,7 @@ class TestTaskRawDataCollection(unittest.TestCase):
         task = TaskRawDataCollection(config, backend_section=backend_section)
         # We need to load the projects
         TaskProjects(config).execute()
-        self.assertEqual(task.execute(), None)
+        self.assertIsNotNone(task.execute())
 
     def test_execute_from_archive(self):
         """Test fetching data from archives"""
@@ -116,7 +116,7 @@ class TestTaskRawDataCollection(unittest.TestCase):
             task = TaskRawDataCollection(config, backend_section=backend_section)
             # We need to load the projects
             TaskProjects(config).execute()
-            self.assertEqual(task.execute(), None)
+            self.assertIsNotNone(task.execute())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR enhances the task collection by making it return a list of errors info for each repo. The list
is shaped as follows:
```
 [
  {
   'backend: 'GitHub',
   'repo': 'https://github.com/chaoss/grimoirelab-perceval',
   'error': 'RateLimit error ...'
  }
]
```