### PR TITLE
Polish travis, requirements.txt and setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,25 +9,12 @@ services:
   - elasticsearch
   - mysql
 
-# addons:
-#    mariadb: '10.0'
-
 before_install:
   - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.0.deb && sudo dpkg -i --force-confnew elasticsearch-6.1.0.deb && sudo service elasticsearch restart
   - pip install httpretty==0.8.6
   - pip install -r "requirements.txt"
   - pip install flake8
   - pip install coveralls
-
-# install:
-#   - ./setup.py install
-
-# To avoid: pymysql.err.OperationalError: (2013, 'Lost connection to MySQL server during query')
-# before_script:
-#  - echo -e "[mysqld]\nnet_read_timeout=180\nnet_write_timeout=180\nmax_allowed_packet=16M\nwait_timeout=2592000\ninteractive_timeout=2592000\nmax_connections=300" | sudo tee -a /etc/mysql/my.cnf
-#  - cat /etc/mysql/my.cnf
-#  - sudo service mysql restart
-#  - echo 'SHOW VARIABLES' | mysql -u root
 
 script:
   - flake8 .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-PyMySQL
-pyyaml
-redis
 elasticsearch==6.3.1
 elasticsearch-dsl==6.3.1
+redis>=2.10.0, <=2.10.6
 -e git+https://github.com/chaoss/grimoirelab-toolkit/#egg=grimoirelab-toolkit
 -e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=grimoirelab-sortinghat
 -e git+https://github.com/chaoss/grimoirelab-manuscripts/#egg=grimoirelab-manuscripts

--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,10 @@ setup(name="sirmordred",
           'kidash>=0.4.13',
           'manuscripts>=0.2.16',
           'sortinghat>=0.7',
-          'PyMySQL',
-          'pyyaml',
-          'redis',
-          'kingarthur>=0.1.12'
+          'kingarthur>=0.1.12',
+          'elasticsearch==6.3.1',
+          'elasticsearch-dsl==6.3.1',
+          'redis>=2.10.0, <=2.10.6'
       ],
       scripts=[
           'bin/sirmordred'


### PR DESCRIPTION
This PR cleans the content of the travis.yml, requirements.txt and setup.py by avoiding installing packages which are installed by other GrimoireLab components. It also aligns the requirements.txt with the install_requires in the setup.py