### PR TITLE
[doc] Update README and examples to use graal backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ SirMordred is the tool used to coordinate the execution of the GrimoireLab platf
  * **gitlab-issues** (bool: False): Enable GitLab issues menu
  * **gitlab-merges** (bool: False): Enable GitLab merge requests menu
  * **mattermost** (bool: False): Enable Mattermost menu
+ * **code-license** (bool: False): Enable code license menu. Note that if enabled, colic sections in the setup.cfg and projects.json should be declared
+ * **code-complexity** (bool: False): Enable code complexity menu. Note that if enabled, cocom sections in the setup.cfg and projects.json should be declared
  * **strict** (bool: True): Enable strict panels loading
 ### [phases]
 

--- a/utils/projects.json
+++ b/utils/projects.json
@@ -3,6 +3,12 @@
         "git": [
             "https://github.com/chaoss/grimoirelab-perceval"
         ],
+        "cocom": [
+            "https://github.com/chaoss/grimoirelab-toolkit"
+        ],
+        "colic": [
+            "https://github.com/chaoss/grimoirelab-toolkit"
+        ],
         "*github": [
             "https://github.com/chaoss/grimoirelab-perceval"
         ],

--- a/utils/setup.cfg
+++ b/utils/setup.cfg
@@ -59,12 +59,14 @@ bots_names = [Beloved Bot]
 
 [panels]
 kibiter_time_from= "now-30y"
-kibiter_default_index= "gitlab"
-kibiter_url = http://localhost:5601
+kibiter_default_index= "git"
+kibiter_url = http://admin:admin@localhost:5601
 community = true
 gitlab-issues = true
 gitlab-merges = true
 github-repos = true
+code-license = true
+code-complexity = true
 
 [phases]
 collection = true
@@ -147,3 +149,26 @@ api-token = nsTwsxkTbnoJBbY3pC43
 no-archive = true
 category = merge_request
 sleep-for-rate = true
+
+[cocom]
+raw_index = cocom_chaoss
+enriched_index = cocom_chaoss_enrich
+category = code_complexity_lizard_file
+studies = [enrich_cocom_analysis]
+branches = master
+
+[enrich_cocom_analysis]
+out_index = cocom_chaoss_study
+interval_months = [3]
+
+[colic]
+raw_index = colic_chaoss
+enriched_index = colic_chaoss_enrich
+category = code_license_nomos
+studies = [enrich_colic_analysis]
+exec-path = /home/slimbook/Escritorio/sources/graal-libs/nomossa
+branches = master
+
+[enrich_colic_analysis]
+out_index = colic_chaoss_study
+interval_months = [6]


### PR DESCRIPTION
This PR enhances the setup.cfg and projects.json by including some examples about how to use graal backends. Furthermore, it also updates the READEME.md with the description of two attributes used to load graal panels:
- code-license, upload license dashboard
- code-complexity, upload code complexity dashboard.