### PR TITLE
[task_identities] Lazy loading of orgs and identities files

### DIFF
--- a/sirmordred/task_identities.py
+++ b/sirmordred/task_identities.py
@@ -23,6 +23,7 @@
 
 import base64
 import gzip
+import hashlib
 import json
 import logging
 import os
@@ -48,6 +49,30 @@ from sortinghat.db.model import Profile
 from grimoire_elk.elk import load_identities
 
 logger = logging.getLogger(__name__)
+
+
+def get_file_hash(filepath):
+    """Generate hash based on the file content
+
+    Read the content of a JSON file, remove all no alphanumeric
+    characters, sort the remaining characters and create a hash from them.
+
+    :param filepath: local path of the file to hash
+    :return: content hash
+    """
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    json_content = json.loads(content)
+    # Remove the attribute time for identities file, since its value changes
+    # any time the file is generated
+    json_content.pop('time', None)
+    json_dump = json.dumps(json_content)
+
+    digest_content = "".join([c if c.isalnum() else "" for c in sorted(json_dump)]).strip()
+    hash_object = hashlib.sha256()
+    hash_object.update(digest_content.encode('utf-8'))
+    return hash_object.hexdigest()
 
 
 class TaskInitSortingHat(Task):

--- a/sirmordred/task_identities.py
+++ b/sirmordred/task_identities.py
@@ -312,7 +312,11 @@ class TaskIdentitiesLoad(Task):
                         logger.error("[sortinghat] Error loading %s", orgs_file)
 
                     self.current_orgs_file_hash = orgs_file_hash
-                # FIXME get the number of loaded orgs
+                    with open(orgs_file, 'r') as f:
+                        json_content = json.loads(f.read())
+                    logger.info("[sortinghat] %s organizations loaded", len(json_content['organizations']))
+                else:
+                    logger.info("[sortinghat] No changes in file %s, organizations won't be loaded", orgs_file)
 
         # Identities loading from files. It could be in several formats.
         # Right now GrimoireLab and SortingHat formats are supported

--- a/sirmordred/task_identities.py
+++ b/sirmordred/task_identities.py
@@ -136,6 +136,7 @@ class TaskIdentitiesLoad(Task):
     def __init__(self, config):
         super().__init__(config)
 
+        self.current_orgs_file_hash = None
         self.sh_kwargs = {'user': self.db_user, 'password': self.db_password,
                           'database': self.db_sh, 'host': self.db_host,
                           'port': None}
@@ -293,10 +294,15 @@ class TaskIdentitiesLoad(Task):
             elif not os.path.exists(cfg['sortinghat']['orgs_file']):
                 logger.error("Orgs file not found on disk")
             else:
-                logger.info("[sortinghat] Loading orgs from file %s", cfg['sortinghat']['orgs_file'])
-                code = Load(**self.sh_kwargs).run("--orgs", cfg['sortinghat']['orgs_file'])
-                if code != CMD_SUCCESS:
-                    logger.error("[sortinghat] Error loading %s", cfg['sortinghat']['orgs_file'])
+                orgs_file = cfg['sortinghat']['orgs_file']
+                orgs_file_hash = get_file_hash(orgs_file)
+                if not self.current_orgs_file_hash or self.current_orgs_file_hash != orgs_file_hash:
+                    logger.info("[sortinghat] Loading orgs from file %s", orgs_file)
+                    code = Load(**self.sh_kwargs).run("--orgs", orgs_file)
+                    if code != CMD_SUCCESS:
+                        logger.error("[sortinghat] Error loading %s", orgs_file)
+
+                    self.current_orgs_file_hash = orgs_file_hash
                 # FIXME get the number of loaded orgs
 
         # Identities loading from files. It could be in several formats.


### PR DESCRIPTION
This PR provides a mechanism to load organization and identities files when a change is detected in their content. In a nutshell, for every organization/identities file, a hash is generated based on its content and stored in `TaskIdentitiesLoad`. If a change is detected on the file hash, the corresponding file is entirely reloaded.

This PR adds also a log message about the number of organizations loaded (it resolves a FIXME comment).

Note that:
1) the initial loop will load organization/identities file, even if the data is already in SortingHat. Adding addtional checks to inspect the database is out of the scope of this PR.
2) if the `reset_on_load` param is set to True, the identities files will be reloaded at every loop.
3) Diff detection and loading of new organization/identities in the corresponding files is out of the scope of this PR.