### PR TITLE
[task_collection] Add filter-no-collection to ignore the collection

### DIFF
--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -105,8 +105,13 @@ class TaskRawDataCollection(Task):
         for repo in repos:
             repo, repo_labels = self._extract_repo_labels(self.backend_section, repo)
             p2o_args = self._compose_p2o_params(self.backend_section, repo)
-            filter_raw = p2o_args['filter-raw'] if 'filter-raw' in p2o_args else None
+            filter_raw = p2o_args.get('filter-raw', None)
+            no_collection = p2o_args.get('filter-no-collection', None)
 
+            if no_collection:
+                # If no-collection is set to true, the repository data is not collected.
+                logging.warning("Not collecting archive repository: %s", repo)
+                continue
             if filter_raw:
                 # If filter-raw exists it means that there is an equivalent URL
                 # in the `unknown` section of the projects.json. Thus the URL with
@@ -422,7 +427,13 @@ class TaskRawDataArthurCollection(Task):
                 self.arthur_items[tag] = []
                 repo, repo_labels = self._extract_repo_labels(self.backend_section, repo)
                 p2o_args = self._compose_p2o_params(self.backend_section, repo)
-                filter_raw = p2o_args['filter-raw'] if 'filter-raw' in p2o_args else None
+                filter_raw = p2o_args.get('filter-raw', None)
+                no_collection = p2o_args.get('filter-no-collection', None)
+
+                if no_collection:
+                    # If no-collection is set to true, the repository data is not collected.
+                    logging.warning("Not collecting archive repository: %s", repo)
+                    continue
                 if filter_raw:
                     # If filter-raw exists it means that there is an equivalent URL
                     # in the `unknown` section of the projects.json. Thus the URL with
@@ -430,6 +441,7 @@ class TaskRawDataArthurCollection(Task):
                     # in `unknown` is considered in this phase.
                     logging.warning("Not collecting filter raw repository: %s", repo)
                     continue
+
                 backend_args = self._compose_perceval_params(self.backend_section, repo)
                 logger.debug(backend_args)
 

--- a/tests/test-no-collection.cfg
+++ b/tests/test-no-collection.cfg
@@ -1,0 +1,71 @@
+#
+# Test config with only git and github activated
+#
+
+
+# Config values format
+#
+# List: [val1, val2 ...]
+# Int: int_value
+# Int as string: "Int"
+# List as string: "[val1, val2 ...]"
+# String: string_value
+# None: None, none
+# Boolean: true, True, False, false
+
+[general]
+short_name = Grimoire
+update = false
+min_update_delay = 10
+debug = true
+# /var/log/sigmordred/
+logs_dir = logs
+# Number of items per bulk request to Elasticsearch
+bulk_size = 100
+# Number of items to get from Elasticsearch when scrolling
+scroll_size = 100
+
+[projects]
+projects_file = test-projects-no-collection.json
+
+[es_collection]
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
+
+[es_enrichment]
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
+autorefresh = false
+
+[sortinghat]
+host = 127.0.0.1
+user = root
+password =
+database = test_sh
+load_orgs = true
+orgs_file = data/orgs_sortinghat.json
+identities_api_token = 'xxxx'
+identities_file = [data/perceval_identities_sortinghat.json]
+affiliate = true
+# commonly: Unknown
+unaffiliated_group = Unknown
+autoprofile = [customer,git,github]
+matching = [email]
+sleep_for = 120
+# sleep_for = 1800
+bots_names = [Beloved Bot]
+
+[panels]
+kibiter_time_from= "now-30y"
+kibiter_default_index= "git"
+kibiter_url = http://localhost:5601
+
+[phases]
+collection = true
+identities = true
+enrichment = true
+panels = true
+
+[git]
+raw_index = git_test-raw-no-coll
+enriched_index = git_test-no-coll

--- a/tests/test-projects-no-collection.json
+++ b/tests/test-projects-no-collection.json
@@ -1,0 +1,8 @@
+{
+  "grimoire": {
+    "git": [
+        "https://github.com/VizGrimoire/GrimoireLib --filter-no-collection=true",
+        "https://github.com/MetricsGrimoire/CMetrics"
+    ]
+  }
+}


### PR DESCRIPTION
This code allows to prevent the collection of repositories listed in the 
projects.json by adding `--filter-no-collection=true` to the corresponding lines.
Tests have been provided accordingly.

An example of projects.json is shown below:
```
{
  "grimoire": {
    "git": [
        "https://github.com/VizGrimoire/GrimoireLib --filter-no-collection=true",
        "https://github.com/MetricsGrimoire/CMetrics"
    ]
  }
}
```