### PR TITLE
[mordred] Make sortinghat optional

### DIFF
--- a/sirmordred/sirmordred.py
+++ b/sirmordred/sirmordred.py
@@ -194,8 +194,9 @@ class SirMordred:
         """
             Just a wrapper to the execute_batch_tasks method
         """
+        sleep_for = self.conf['sortinghat']['sleep_for'] if self.conf.get('sortinghat', None) else 1
         self.execute_batch_tasks(tasks_cls,
-                                 self.conf['sortinghat']['sleep_for'],
+                                 sleep_for,
                                  self.conf['general']['min_update_delay'], False)
 
     def execute_batch_tasks(self, tasks_cls, big_delay=0, small_delay=0, wait_for_threads=True):
@@ -368,11 +369,12 @@ class SirMordred:
 
             try:
                 if not self.conf['general']['update']:
+                    sleep_for = self.conf['sortinghat']['sleep_for'] if self.conf.get('sortinghat', None) else 1
                     self.execute_batch_tasks(all_tasks_cls,
-                                             self.conf['sortinghat']['sleep_for'],
+                                             sleep_for,
                                              self.conf['general']['min_update_delay'])
                     self.execute_batch_tasks(all_tasks_cls,
-                                             self.conf['sortinghat']['sleep_for'],
+                                             sleep_for,
                                              self.conf['general']['min_update_delay'])
                     break
                 else:

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -44,10 +44,18 @@ class Task():
         self.backend_section = None
         self.config = config
         self.conf = config.get_conf()
-        self.db_sh = self.conf['sortinghat']['database']
-        self.db_user = self.conf['sortinghat']['user']
-        self.db_password = self.conf['sortinghat']['password']
-        self.db_host = self.conf['sortinghat']['host']
+
+        sortinghat = self.conf.get('sortinghat', None)
+        self.db_sh = sortinghat['database'] if sortinghat else None
+        self.db_user = sortinghat['user'] if sortinghat else None
+        self.db_password = sortinghat['password'] if sortinghat else None
+        self.db_host = sortinghat['host'] if sortinghat else None
+        self.db_unaffiliate_group = sortinghat['unaffiliated_group'] if sortinghat else None
+
+        self.sh_kwargs = {'user': self.db_user, 'password': self.db_password,
+                          'database': self.db_sh, 'host': self.db_host,
+                          'port': None}
+
         self.grimoire_con = grimoire_con(conn_retries=12)  # 30m retry
 
     @staticmethod

--- a/sirmordred/task_identities.py
+++ b/sirmordred/task_identities.py
@@ -81,10 +81,6 @@ class TaskInitSortingHat(Task):
     def __init__(self, config):
         super().__init__(config)
 
-        self.sh_kwargs = {'user': self.db_user, 'password': self.db_password,
-                          'database': self.db_sh, 'host': self.db_host,
-                          'port': None}
-
     def is_backend_task(self):
         return False
 
@@ -104,9 +100,6 @@ class TaskIdentitiesCollection(Task):
         super().__init__(config)
 
         self.load_ids = load_ids  # Load identities from raw index
-        self.sh_kwargs = {'user': self.db_user, 'password': self.db_password,
-                          'database': self.db_sh, 'host': self.db_host,
-                          'port': None}
 
     def execute(self):
 
@@ -138,9 +131,6 @@ class TaskIdentitiesLoad(Task):
 
         self.current_orgs_file_hash = None
         self.current_identities_files_hash = {}
-        self.sh_kwargs = {'user': self.db_user, 'password': self.db_password,
-                          'database': self.db_sh, 'host': self.db_host,
-                          'port': None}
 
     def is_backend_task(self):
         return False
@@ -354,10 +344,6 @@ class TaskIdentitiesExport(Task):
     def __init__(self, config):
         super().__init__(config)
 
-        self.sh_kwargs = {'user': self.db_user, 'password': self.db_password,
-                          'database': self.db_sh, 'host': self.db_host,
-                          'port': None}
-
     def is_backend_task(self):
         return False
 
@@ -461,10 +447,6 @@ class TaskIdentitiesMerge(Task):
 
     def __init__(self, conf):
         super().__init__(conf)
-
-        self.sh_kwargs = {'user': self.db_user, 'password': self.db_password,
-                          'database': self.db_sh, 'host': self.db_host,
-                          'port': None}
         self.db = Database(**self.sh_kwargs)
         self.last_autorefresh = datetime.utcnow()  # Last autorefresh date
 

--- a/tests/data/url-projects.json
+++ b/tests/data/url-projects.json
@@ -25,7 +25,7 @@
    "review.openstack.org"
   ],
   "git": [
-   "https://github.com/VizGrimoire/GrimoireLib --filters-raw-prefix data.files.file:grimoirelib_alch data.files.file:README.md",
+   "https://github.com/VizGrimoire/GrimoireLib --filter-raw-prefix=data.files.file:grimoirelib_alch,data.files.file:README.md",
    "https://github.com/MetricsGrimoire/CMetrics"
   ],
   "gitlab": [

--- a/tests/test-no-sh.cfg
+++ b/tests/test-no-sh.cfg
@@ -1,0 +1,244 @@
+#
+# Test config with only git and github activated
+#
+
+
+# Config values format
+#
+# List: [val1, val2 ...]
+# Int: int_value
+# Int as string: "Int"
+# List as string: "[val1, val2 ...]"
+# String: string_value
+# None: None, none
+# Boolean: true, True, False, false
+
+[general]
+short_name = Grimoire
+update = false
+min_update_delay = 10
+debug = true
+# /var/log/sigmordred/
+logs_dir = logs
+# Number of items per bulk request to Elasticsearch
+bulk_size = 100
+# Number of items to get from Elasticsearch when scrolling
+scroll_size = 100
+
+[projects]
+projects_file = test-projects.json
+
+[es_collection]
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
+
+[es_enrichment]
+url = http://localhost:9200
+# url = https://admin:admin@localhost:9200
+autorefresh = false
+
+[panels]
+kibiter_time_from= "now-30y"
+kibiter_default_index= "git"
+kibiter_url = http://localhost:5601
+
+[phases]
+collection = true
+identities = true
+enrichment = true
+panels = true
+
+[askbot]
+collect = false
+raw_index = askbot_test-raw
+enriched_index = askbot_test
+
+[bugzilla]
+raw_index = bugzilla_test-raw
+enriched_index = bugzilla-test
+
+[bugzillarest]
+raw_index = bugzillarest_test-raw
+enriched_index = bugzillarest_test
+
+[confluence]
+raw_index = confluence_test-raw
+enriched_index = confluence_test
+
+[discourse]
+raw_index = discourse_test-raw
+enriched_index = discourse_test
+
+[dockerhub]
+raw_index = dockerhub_test-raw
+enriched_index = dockerhub_test
+
+[functest]
+collect=False
+raw_index = functest_test-raw
+enriched_index = functest_test
+
+[gerrit]
+raw_index = gerrit_test-raw
+enriched_index = gerrit_test
+user = acs
+
+[git]
+raw_index = git_test-raw
+enriched_index = git_test
+studies = []
+
+[enrich_demography:1]
+date_field = grimoire_creation_date
+author_field =  author_uuid
+
+[enrich_areas_of_code]
+in_index = git_test-raw
+out_index = git_test-aoc
+
+[enrich_onion]
+in_index = git_test
+out_index = git_test-onion
+contribs_field = hash
+no_incremental = true
+
+[github]
+raw_index = github_test-raw
+enriched_index = github_test
+api-token = XXXXX
+sleep-for-rate = true
+archive-path = /tmp/test_github_archive
+category = issue
+sleep-time = 300
+
+[github:pull]
+raw_index = github_test-raw-pull
+enriched_index = github_test-pull
+api-token = XXXXX
+sleep-for-rate = true
+archive-path = /tmp/test_github_archive
+category = pull_request
+sleep-time = 300
+
+[gitlab]
+raw_index = test_gitlab-raw
+enriched_index = test_gitlab
+api-token = xxxx
+no-archive = true
+
+[google_hits]
+raw_index = google_hits_test-raw
+enriched_index =google_hits_test
+
+[hyperkitty]
+raw_index = hyperkitty_test-raw
+enriched_index = hyperkitty_test
+from-date = 2017-01-01
+
+[jenkins]
+raw_index = jenkins_test-raw
+enriched_index = jenkins_test
+
+[jira]
+raw_index = jira_test-raw
+enriched_index = jira_test
+project = PUP
+
+[mattermost]
+raw_index = mattermost_test
+enriched_index = mattermost_test_enriched
+api-token = xxx
+
+[mattermost:group1]
+raw_index = mattermost_test_group1
+enriched_index = mattermost_test_enriched_group1
+api-token = xxx
+
+[mattermost:group2]
+raw_index = mattermost_test_group2
+enriched_index = mattermost_test_enriched_group2
+api-token = zzz
+
+[mbox]
+raw_index = mbox_test-raw
+enriched_index = mbox_test
+
+[kafka_kip]
+no_incremental = true
+
+[mediawiki]
+raw_index = mediawiki_test-raw
+enriched_index = mediawiki_test
+
+[meetup]
+raw_index = meetup_test-raw
+enriched_index =  meetup_test
+api-token = XXXXX
+
+[mozillaclub]
+raw_index = mozillaclub_test-raw
+enriched_index = mozillaclub_test
+
+[nntp]
+raw_index = nntp_grimoire_test-raw
+enriched_index =  nntp_grimoire_test
+
+[phabricator]
+raw_index = phabricator_test-raw
+enriched_index = phabricator_test
+api-token = XXXXX
+
+[pipermail]
+raw_index = pipermail_test-raw
+enriched_index = pipermail_test
+
+[puppetforge]
+raw_index = puppetforge_test-raw
+enriched_index = puppetforge_test
+
+[redmine]
+raw_index = redmine_test-raw
+enriched_index = redmine_test
+api-token = XXXXX
+
+[remo]
+raw_index = remo_test-raw
+enriched_index = remo_test
+
+[remo:activities]
+# Perceval archive already used in [remo]
+collect = false
+raw_index = remo_activities_test-raw
+enriched_index = remo_activities_test
+no-archive = true
+
+[rss]
+raw_index = rss_test-raw
+enriched_index = rss_test
+
+[stackexchange]
+es_collection_url = http://127.0.0.1:9200
+raw_index = stackexchange_test-raw
+enriched_index = stackexchange_test
+api-token = XXXXX
+
+[slack]
+raw_index = slack_test-raw
+enriched_index = slack_test
+api-token = XXXXX
+
+[supybot]
+raw_index = supybot_test-raw
+enriched_index = supybot_test
+from-date = 2000-12-09
+
+[telegram]
+raw_index = telegram_test-raw
+enriched_index = telegram_test
+api-token = XXXXX
+
+[twitter]
+collect = false
+raw_index = twitter_test-raw
+enriched_index = twitter_test
+api-token = XXXX

--- a/tests/test_task_collection.py
+++ b/tests/test_task_collection.py
@@ -41,6 +41,8 @@ PROJ_FILE = 'test-projects.json'
 CONF_FILE_NO_COLL = 'test-no-collection.cfg'
 PROJ_FILE_NO_COLL = 'test-projects-no-collection.json'
 
+CONF_ARCHIVE_FILE = 'archives-test.cfg'
+
 HOME_USER = expanduser("~")
 PERCEVAL_ARCHIVE = join(HOME_USER, '.perceval')
 
@@ -145,8 +147,7 @@ class TestTaskRawDataCollection(unittest.TestCase):
         """Test fetching data from archives"""
 
         # proj_file -> 'test-projects-archive.json' stored within the conf file
-        conf_file = 'archives-test.cfg'
-        config = Config(conf_file)
+        config = Config(CONF_ARCHIVE_FILE)
 
         backend_sections = ['askbot', 'bugzilla', 'bugzillarest', 'confluence',
                             'discourse', 'dockerhub', 'gerrit', 'github:issue', 'github:pull',

--- a/tests/test_task_projects.py
+++ b/tests/test_task_projects.py
@@ -194,7 +194,7 @@ class TestTaskProjects(unittest.TestCase):
         repos.sort()
         expected_list = [
             "https://github.com/VizGrimoire/GrimoireLib "
-            "--filters-raw-prefix data.files.file:grimoirelib_alch data.files.file:README.md",
+            "--filter-raw-prefix=data.files.file:grimoirelib_alch,data.files.file:README.md",
             "https://github.com/MetricsGrimoire/CMetrics"]
         expected_list.sort()
         self.assertEqual(backend, 'git')


### PR DESCRIPTION
This code allows to decouple sortinghat from the rest of the platform. It worth mentioning that the platform will fail in case the `identities` phase is enabled and the `sortinghat` section is not given in the setup.cfg 

Related to https://github.com/chaoss/grimoirelab-sirmordred/issues/342