### PR TITLE
[travis] Support for python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 


### PR DESCRIPTION
This code aims at aligning the CI tests across the different grimoirelab components.

Python 3.4 is removed where possible and
Python 3.5 and 3.6 are now supported.