### PR TITLE
[mordred] Decommission bot names params from setup.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ is stored. Furthermore, it also includes backend sections to set up the paramete
  * **affiliate** (bool: True): Affiliate identities to organizations (**Required**)
  * **autogender** (bool: False): Add gender to the profiles (executes autogender)
  * **autoprofile** (list: ['customer', 'git', 'github']): Order in which to get the identities information for filling the profile (**Required**)
- * **bots_names** (list: []): Name of the identities to be marked as bots
  * **database** (str: sortinghat_db): Name of the Sortinghat database (**Required**)
  * **host** (str: mariadb): Host with the Sortinghat database (**Required**)
  * **identities_api_token** (str: None): API token for remote operation with GitHub and Gitlab
@@ -80,7 +79,6 @@ is stored. Furthermore, it also includes backend sections to set up the paramete
  * **identities_format** (str: sortinghat): Format of the identities data to be loaded
  * **load_orgs** (bool: False): 
  * **matching** (list: ['email']): Algorithm for matching identities in Sortinghat (**Required**)
- * **no_bots_names** (list: []): Name of the identities to be unmarked as bots
  * **orgs_file** (str: None): File path with the organizations to be loaded in Sortinghat
  * **password** (str: ): Password to access the Sortinghat database (**Required**)
  * **reset_on_load** (bool: False): Unmerge and remove affiliations for all identities on load

--- a/doc/config.md
+++ b/doc/config.md
@@ -66,7 +66,6 @@ Use python mordred/config.py to generate it.
  * **affiliate** (bool: True): Affiliate identities to organizations (**Required**)
  * **autogender** (bool: False): Add gender to the profiles (executes autogender)
  * **autoprofile** (list: ['customer', 'git', 'github']): Order in which to get the identities information for filling the profile (**Required**)
- * **bots_names** (list: []): Name of the identities to be marked as bots
  * **database** (str: sortinghat_db): Name of the Sortinghat database (**Required**)
  * **host** (str: mariadb): Host with the Sortinghat database (**Required**)
  * **identities_api_token** (str: None): API token for remote operation with GitHub and Gitlab
@@ -75,7 +74,6 @@ Use python mordred/config.py to generate it.
  * **identities_format** (str: sortinghat): Format of the identities data to be loaded
  * **load_orgs** (bool: False): 
  * **matching** (list: ['email']): Algorithm for matching identities in Sortinghat (**Required**)
- * **no_bots_names** (list: []): Name of the identities to be unmarked as bots
  * **orgs_file** (str: None): File path with the organizations to be loaded in Sortinghat
  * **password** (str: ): Password to access the Sortinghat database (**Required**)
  * **reset_on_load** (bool: False): Unmerge and remove affiliations for all identities on load

--- a/docker/README.md
+++ b/docker/README.md
@@ -107,7 +107,6 @@ orgs_file = [/home/bitergia/conf/orgs_file.json]
 matching = [email-name, github]
 autoprofile = [customer, git, github]
 sleep_for = 86400
-bots_names = [Beloved Bot]
 unaffiliated_group = Unknown
 ```
 

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -505,18 +505,6 @@ class Config():
                     "type": str,
                     "description": "API token for remote operation with GitHub and Gitlab"
                 },
-                "bots_names": {
-                    "optional": True,
-                    "default": [],
-                    "type": list,
-                    "description": "Name of the identities to be marked as bots"
-                },
-                "no_bots_names": {
-                    "optional": True,
-                    "default": [],
-                    "type": list,
-                    "description": "Name of the identities to be unmarked as bots"
-                },
                 "autogender": {
                     "optional": True,
                     "default": False,

--- a/sirmordred/task_identities.py
+++ b/sirmordred/task_identities.py
@@ -38,7 +38,6 @@ import requests
 
 from sirmordred.task import Task
 from sirmordred.task_manager import TasksManager
-from sortinghat import api
 from sortinghat.cmd.init import Init
 from sortinghat.cmd.load import Load
 from sortinghat.cmd.export import Export
@@ -570,28 +569,6 @@ class TaskIdentitiesMerge(Task):
         else:
             logger.info("[sortinghat] Executing autogender")
             self.do_autogender()
-
-        if 'bots_names' not in cfg['sortinghat']:
-            logger.info("[sortinghat] Bots name list not configured. Skipping.")
-        else:
-            logger.info("[sortinghat] Marking bots: %s",
-                        cfg['sortinghat']['bots_names'])
-            for name in cfg['sortinghat']['bots_names']:
-                # First we need the uuids for the profile name
-                uuids = self.__get_uuids_from_profile_name(name)
-                # Then we can modify the profile setting bot flag
-                profile = {"is_bot": True}
-                for uuid in uuids:
-                    api.edit_profile(self.db, uuid, **profile)
-            # For quitting the bot flag - debug feature
-            if 'no_bots_names' in cfg['sortinghat']:
-                logger.info("[sortinghat] Removing Marking bots: %s",
-                            cfg['sortinghat']['no_bots_names'])
-                for name in cfg['sortinghat']['no_bots_names']:
-                    uuids = self.__get_uuids_from_profile_name(name)
-                    profile = {"is_bot": False}
-                    for uuid in uuids:
-                        api.edit_profile(self.db, uuid, **profile)
 
         with TasksManager.IDENTITIES_TASKS_ON_LOCK:
             TasksManager.IDENTITIES_TASKS_ON = False

--- a/tests/archives-test.cfg
+++ b/tests/archives-test.cfg
@@ -56,7 +56,6 @@ autoprofile = [customer,git,github]
 matching = [email]
 sleep_for = 120
 # sleep_for = 1800
-bots_names = [Beloved Bot]
 
 [panels]
 kibiter_time_from= "now-30y"

--- a/tests/data/task-params-test.cfg
+++ b/tests/data/task-params-test.cfg
@@ -44,7 +44,6 @@ autoprofile = [customer,git,github]
 matching = [email]
 sleep_for = 120
 # sleep_for = 1800
-bots_names = [Beloved Bot]
 
 [panels]
 kibiter_time_from= "now-30y"

--- a/tests/test-no-collection.cfg
+++ b/tests/test-no-collection.cfg
@@ -53,7 +53,6 @@ autoprofile = [customer,git,github]
 matching = [email]
 sleep_for = 120
 # sleep_for = 1800
-bots_names = [Beloved Bot]
 
 [panels]
 kibiter_time_from= "now-30y"

--- a/tests/test-repos.cfg
+++ b/tests/test-repos.cfg
@@ -52,7 +52,6 @@ autoprofile = [customer,git,github]
 matching = [email]
 sleep_for = 120
 # sleep_for = 1800
-bots_names = [Beloved Bot]
 
 [panels]
 kibiter_time_from= "now-30y"

--- a/tests/test.cfg
+++ b/tests/test.cfg
@@ -53,7 +53,6 @@ autoprofile = [customer,git,github]
 matching = [email]
 sleep_for = 120
 # sleep_for = 1800
-bots_names = [Beloved Bot]
 
 [panels]
 kibiter_time_from= "now-30y"

--- a/tests/test_studies.cfg
+++ b/tests/test_studies.cfg
@@ -54,7 +54,6 @@ autoprofile = [customer,git,github]
 matching = [email]
 sleep_for = 120
 # sleep_for = 1800
-bots_names = [Beloved Bot]
 
 [panels]
 kibiter_time_from= "now-30y"

--- a/tests/test_wrong.cfg
+++ b/tests/test_wrong.cfg
@@ -54,7 +54,6 @@ autoprofile = [customer,git,github]
 matching = [email]
 sleep_for = 120
 # sleep_for = 1800
-bots_names = [Beloved Bot]
 
 [panels]
 kibiter_time_from= "now-30y"


### PR DESCRIPTION
This code decomissions the sortinghat params `bots_names` and `no_bots_names` from the setup.cfg. Task identities, config, tests data and documentation have been updated accordingly.

Related to https://github.com/chaoss/grimoirelab-sirmordred/issues/369