### PR TITLE
[sirmordred] Delete support to log rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ is stored. Furthermore, it also includes backend sections to set up the paramete
 
  * **bulk_size** (int: 1000): Number of items to write in Elasticsearch using bulk operations
  * **debug** (bool: True): Debug mode (logging mainly) (**Required**)
- * **log_backup_count** (int: 5): Number of rotate logs files to preserve
- * **log_handler** (str: file): use rotate for rotating the logs automatically
- * **log_max_bytes** (int: 104857600): Max number of bytes per log file
  * **logs_dir** (str: logs): Directory with the logs of sirmordred (**Required**)
  * **min_update_delay** (int: 60): Short delay between tasks (collect, enrich ...)
  * **scroll_size** (int: 100): Number of items to read from Elasticsearch when scrolling

--- a/bin/sirmordred
+++ b/bin/sirmordred
@@ -23,12 +23,10 @@
 
 
 import argparse
-import configparser
 import logging
 import logging.handlers
 import os
 import sys
-import traceback
 
 sys.path.insert(1, '.')
 
@@ -39,13 +37,11 @@ warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 
 from sirmordred.config import Config
-from sirmordred.error import ElasticSearchError
-from sirmordred.error import DataCollectionError
 from sirmordred.sirmordred import SirMordred
 
 
 SLEEPFOR_ERROR = """Error: You may be Arthur, King of the Britons. But you still """ + \
-"""need the 'sleep_for' variable in sortinghat section\n - Sir Mordred said."""
+                 """need the 'sleep_for' variable in sortinghat section\n - Sir Mordred said."""
 
 logger = logging.getLogger(__name__)
 
@@ -85,29 +81,30 @@ def setup_logs(logs_dir, debug_mode):
 
     return logger
 
-def parse_args():
 
+def parse_args():
     parser = argparse.ArgumentParser(
         description='SirMordred, the friendly friend of GrimoireELK',
         epilog='Software metrics for your peace of mind'
-        )
+    )
 
-    parser.add_argument('-c','--config', help='Configuration files',
+    parser.add_argument('-c', '--config', help='Configuration files',
                         type=str, nargs='+', default=['mordred.cfg'],
                         dest='config_files')
-    parser.add_argument('-t','--template', help='Create template configuration file',
+    parser.add_argument('-t', '--template', help='Create template configuration file',
                         dest='config_template_file')
-    parser.add_argument('-p','--phases', nargs='*',
+    parser.add_argument('-p', '--phases', nargs='*',
                         help='List of phases to execute (update is set to false)')
 
     args = parser.parse_args()
     return args
 
+
 if __name__ == '__main__':
     args = parse_args()
     if args.config_template_file is not None:
         Config.create_config_file(args.config_template_file)
-        logger.info("Sample config file created in %s", args.config_template_file)
+        logger.info("Sample config file created in {}".format(args.config_template_file))
         sys.exit(0)
     elif args.config_files is None:
         logger.error("Option -t or -c is required")
@@ -120,11 +117,11 @@ if __name__ == '__main__':
         debug_mode = config_dict['general']['debug']
         logger = setup_logs(logs_dir, debug_mode)
     except RuntimeError as error:
-        print("Error while consuming configuration: ", error)
+        print("Error while consuming configuration: {}".format(error))
         sys.exit(1)
 
     if args.phases:
-        logger.info("Executing sirmordred for phases: %s", args.phases)
+        logger.info("Executing sirmordred for phases: {}".format(args.phases))
         # HACK: the internal dict of Config is modified directly
         # In manual phases execute sirmordred as an script
         config_dict['general']['update'] = False

--- a/bin/sirmordred
+++ b/bin/sirmordred
@@ -50,27 +50,19 @@ SLEEPFOR_ERROR = """Error: You may be Arthur, King of the Britons. But you still
 logger = logging.getLogger(__name__)
 
 
-def setup_logs(logs_dir, debug_mode, log_file_handler, max_bytes, backup_count):
+def setup_logs(logs_dir, debug_mode):
 
     if debug_mode:
         logging_mode = logging.DEBUG
     else:
         logging_mode = logging.INFO
 
-    log_file_handler_kwargs = {}
-    if log_file_handler == "rotate":
-        log_file_handler = logging.handlers.RotatingFileHandler
-        log_file_handler_kwargs['maxBytes'] = max_bytes
-        log_file_handler_kwargs['backupCount'] = backup_count
-    else:
-        log_file_handler = logging.FileHandler
-
     logger = logging.getLogger()
     logger.setLevel(logging_mode)
     # create file handler which logs even debug messages
 
-    fh_filepath = os.path.join(logs_dir,'all.log')
-    fh = log_file_handler(fh_filepath, **log_file_handler_kwargs)
+    fh_filepath = os.path.join(logs_dir, 'all.log')
+    fh = logging.FileHandler(fh_filepath)
     fh.setLevel(logging_mode)
     # create console handler with a higher log level
     ch = logging.StreamHandler()
@@ -126,10 +118,7 @@ if __name__ == '__main__':
         config_dict = config.get_conf()
         logs_dir = config_dict['general']['logs_dir']
         debug_mode = config_dict['general']['debug']
-        log_file_handler = config_dict['general']['log_handler']
-        log_max_bytes = config_dict['general']['log_max_bytes']
-        log_backup_count = config_dict['general']['log_backup_count']
-        logger = setup_logs(logs_dir, debug_mode, log_file_handler, log_max_bytes, log_backup_count)
+        logger = setup_logs(logs_dir, debug_mode)
     except RuntimeError as error:
         print("Error while consuming configuration: ", error)
         sys.exit(1)

--- a/doc/config.md
+++ b/doc/config.md
@@ -24,9 +24,6 @@ Use python mordred/config.py to generate it.
 
  * **bulk_size** (int: 1000): Number of items to include in Elasticsearch bulk operations
  * **debug** (bool: True): Debug mode (logging mainly) (**Required**)
- * **log_backup_count** (int: 5): Number of rotate logs files to preserve
- * **log_handler** (str: file): use rotate for rotating the logs automatically
- * **log_max_bytes** (int: 104857600): Max number of bytes per log file
  * **logs_dir** (str: logs): Directory with the logs of mordred (**Required**)
  * **min_update_delay** (int: 60): Short delay between tasks (collect, enrich ...)
  * **scroll_size** (int: 100): Number of items to receive in Elasticsearch when scrolling

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -126,24 +126,6 @@ class Config():
                     "type": str,
                     "description": "Directory with the logs of sirmordred"
                 },
-                "log_handler": {
-                    "optional": True,
-                    "default": "file",
-                    "type": str,
-                    "description": "use rotate for rotating the logs automatically"
-                },
-                "log_max_bytes": {
-                    "optional": True,
-                    "default": 104857600,  # 100MB
-                    "type": int,
-                    "description": "Max number of bytes per log file"
-                },
-                "log_backup_count": {
-                    "optional": True,
-                    "default": 5,
-                    "type": int,
-                    "description": "Number of rotate logs files to preserve"
-                },
                 "bulk_size": {
                     "optional": True,
                     "default": 1000,


### PR DESCRIPTION
This PR removes support to log rotation so the parameters 'log_file_handler', 'max_bytes' and 'backup_count' are not longer valid in config.py. These params are removed from 'setup_logs()' and config.md and README.md have been updated accordingly. Furthermore, this PR removes from 'bin/sirmordred' the imports for configparser, traceback, ElasticSearchError and DatacollectionError since not used , and finally log messages are formatted with 'format()' with the aim of aligning them to the recent changes in ELK.