### PR TITLE
[task_panels] Include OSPO panels in community menu

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -1,30 +1,30 @@
 {
   "askbot": {
       "raw": ["askbot-raw"],
-      "enrich": ["askbot", "affiliations"]
+      "enrich": ["askbot", "affiliations", "all_enriched"]
   },
   "apache": {
       "raw": ["apache"]
   },
   "bugzilla": {
       "raw": ["bugzilla-raw"],
-      "enrich": ["bugzilla", "affiliations"]
+      "enrich": ["bugzilla", "affiliations", "all_enriched"]
   },
   "bugzillarest": {
       "raw": ["bugzilla-raw"],
-      "enrich": ["bugzilla", "affiliations"]
+      "enrich": ["bugzilla", "affiliations", "all_enriched"]
   },
   "crates": {
       "raw": ["crates-raw"],
-      "enrich": ["crate", "affiliations"]
+      "enrich": ["crate", "affiliations", "all_enriched"]
   },
   "confluence": {
       "raw": ["confluence-raw"],
-      "enrich": ["confluence", "affiliations"]
+      "enrich": ["confluence", "affiliations", "all_enriched"]
   },
   "discourse": {
       "raw": ["discourse-raw"],
-      "enrich": ["discourse", "affiliations"]
+      "enrich": ["discourse", "affiliations", "all_enriched"]
   },
   "dockerhub": {
       "raw": ["dockerhub-raw"],
@@ -32,7 +32,7 @@
   },
   "finosmeetings": {
       "raw": ["finosmeetings-raw"],
-      "enrich": ["finosmeetings", "affiliations"]
+      "enrich": ["finosmeetings", "affiliations", "all_enriched"]
   },
   "functest": {
       "raw": ["functest-raw"],
@@ -40,11 +40,11 @@
   },
   "gerrit": {
       "raw": ["gerrit-raw"],
-      "enrich": ["gerrit", "affiliations"]
+      "enrich": ["gerrit", "affiliations", "all_enriched"]
   },
   "git": {
       "raw": ["git-raw"],
-      "enrich": ["git", "git_author", "git_enrich", "affiliations"]
+      "enrich": ["git", "git_author", "git_enrich", "affiliations", "all_enriched"]
   },
   "github:repo": {
       "raw": ["github_repositories-raw"],
@@ -53,15 +53,15 @@
   "github": {
       "raw": ["github-raw"],
       "enrich": ["github_issues", "github_issues_enrich", "issues_closed",
-                 "issues_created", "issues_updated", "affiliations"]
+                 "issues_created", "issues_updated", "affiliations", "all_enriched"]
   },
   "gitlab:issue": {
       "raw": ["gitlab_issues-raw"],
-      "enrich": ["gitlab_issues", "affiliations"]
+      "enrich": ["gitlab_issues", "affiliations", "all_enriched"]
   },
   "gitlab:merge": {
       "raw": ["gitlab_merge_requests-raw"],
-      "enrich": ["gitlab_merge_requests", "affiliations"]
+      "enrich": ["gitlab_merge_requests", "affiliations", "all_enriched"]
   },
   "google_hits": {
       "raw": ["google-hits-raw"],
@@ -69,11 +69,11 @@
   },
   "hyperkitty": {
       "raw": ["hyperkitty-raw"],
-      "enrich": ["mbox", "kafka", "affiliations"]
+      "enrich": ["mbox", "kafka", "affiliations", "all_enriched"]
   },
   "groupsio": {
       "raw": ["groupsio-raw"],
-      "enrich": ["mbox", "kafka", "affiliations"]
+      "enrich": ["mbox", "kafka", "affiliations", "all_enriched"]
   },
   "jenkins": {
       "raw": ["jenkins-raw"],
@@ -81,82 +81,82 @@
   },
   "jira": {
       "raw": ["jira-raw"],
-      "enrich": ["jira", "jira_resolution_date", "affiliations"]
+      "enrich": ["jira", "jira_resolution_date", "affiliations", "all_enriched"]
   },
   "kitsune": {
       "raw": ["kitsune-raw"],
-      "enrich": ["kitsune", "affiliations"]
+      "enrich": ["kitsune", "affiliations", "all_enriched"]
   },
   "mattermost": {
       "raw": ["mattermost-raw"],
-      "enrich": ["mattermost", "affiliations"]
+      "enrich": ["mattermost", "affiliations", "all_enriched"]
   },
   "mbox": {
       "raw": ["mbox-raw"],
-      "enrich": ["mbox", "kafka", "affiliations"]
+      "enrich": ["mbox", "kafka", "affiliations", "all_enriched"]
   },
   "mediawiki": {
       "raw": ["mediawiki-raw"],
-      "enrich": ["mediawiki", "affiliations"]
+      "enrich": ["mediawiki", "affiliations", "all_enriched"]
   },
   "meetup": {
       "raw": ["meetup-raw"],
-      "enrich": ["meetup", "affiliations"]
+      "enrich": ["meetup", "affiliations", "all_enriched"]
   },
   "mozillaclub": {
       "raw": ["mozillaclub-raw"],
-      "enrich": ["mozillaclub", "affiliations"]
+      "enrich": ["mozillaclub", "affiliations", "all_enriched"]
   },
   "nntp": {
       "raw": ["nntp-raw"],
-      "enrich": ["mbox", "kafka", "affiliations"]
+      "enrich": ["mbox", "kafka", "affiliations", "all_enriched"]
   },
   "phabricator": {
       "raw": ["phabricator-raw"],
-      "enrich": ["phabricator", "maniphest", "affiliations"]
+      "enrich": ["phabricator", "maniphest", "affiliations", "all_enriched"]
   },
   "pipermail": {
       "raw": ["pipermail-raw"],
-      "enrich": ["mbox", "kafka", "affiliations"]
+      "enrich": ["mbox", "kafka", "affiliations", "all_enriched"]
   },
   "puppetforge": {
       "raw": ["puppetforge-raw"],
-      "enrich": ["puppetforge", "affiliations"]
+      "enrich": ["puppetforge", "affiliations", "all_enriched"]
   },
   "redmine": {
       "raw": ["redmine-raw"],
-      "enrich": ["redmine", "affiliations"]
+      "enrich": ["redmine", "affiliations", "all_enriched"]
   },
   "remo": {
       "raw": ["remo-raw"],
-      "enrich": ["remo", "remo-events", "remo-events_metadata__timestamp", "affiliations"]
+      "enrich": ["remo", "remo-events", "remo-events_metadata__timestamp", "affiliations", "all_enriched"]
   },
   "remo:activities": {
       "raw": ["remo_activities-raw"],
-      "enrich": ["remo-activities", "remo-activities_metadata__timestamp", "affiliations"]
+      "enrich": ["remo-activities", "remo-activities_metadata__timestamp", "affiliations", "all_enriched"]
   },
   "rss": {
       "raw": ["rss-raw"],
-      "enrich": ["rss", "affiliations"]
+      "enrich": ["rss", "affiliations", "all_enriched"]
   },
   "slack": {
       "raw": ["slack-raw"],
-      "enrich": ["slack", "affiliations"]
+      "enrich": ["slack", "affiliations", "all_enriched"]
   },
   "stackexchange": {
       "raw": ["stackexchange-raw"],
-      "enrich": ["stackoverflow", "affiliations"]
+      "enrich": ["stackoverflow", "affiliations", "all_enriched"]
   },
   "supybot": {
       "raw": ["supybot-raw"],
-      "enrich": ["supybot", "affiliations"]
+      "enrich": ["supybot", "affiliations", "all_enriched"]
   },
   "telegram": {
       "raw": ["telegram-raw"],
-      "enrich": ["telegram", "affiliations"]
+      "enrich": ["telegram", "affiliations", "all_enriched"]
   },
   "twitter": {
       "raw": ["twitter-raw"],
-      "enrich": ["twitter", "affiliations"]
+      "enrich": ["twitter", "affiliations", "all_enriched"]
   }
 }

--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -63,12 +63,18 @@ ONION_PANEL_PROJECTS = 'panels/json/onion_projects.json'
 ONION_PANEL_ORGS = 'panels/json/onion_organizations.json'
 DEMOGRAPHICS = 'panels/json/demographics.json'
 AFFILIATIONS = 'panels/json/affiliations.json'
+CONTRIBUTIONS_GROWTH = 'panels/json/contributors_growth.json'
+ENGAGEMENT_BY_CONTRIBUTIONS = 'panels/json/engagement_by_contributions.json'
+ORGANIZATIONAL_DIVERSITY = 'panels/json/organizational_diversity.json'
+ORGANIZATIONAL_DIVERSITY_BY_DOMAINS = 'panels/json/organizational_diversity_by_domains.json'
 
 ONION_PANEL_OVERALL_IP = 'panels/json/all_onion-index-pattern.json'
 ONION_PANEL_PROJECTS_IP = 'panels/json/all_onion-index-pattern.json'
 ONION_PANEL_ORGS_IP = 'panels/json/all_onion-index-pattern.json'
 DEMOGRAPHICS_IP = 'panels/json/demographics-index-pattern.json'
 AFFILIATIONS_IP = 'panels/json/affiliations-index-pattern.json'
+ALL_ENRICHED_IP = 'panels/json/all_enriched-index-pattern.json'
+ALL_ENRICHED_TICKETS_IP = 'panels/json/all_enriched_tickets-index-pattern.json'
 
 COMMUNITY_MENU = {
     'name': COMMUNITY_NAME,
@@ -79,14 +85,20 @@ COMMUNITY_MENU = {
         ONION_PANEL_PROJECTS_IP,
         ONION_PANEL_ORGS_IP,
         DEMOGRAPHICS_IP,
-        AFFILIATIONS_IP
+        AFFILIATIONS_IP,
+        ALL_ENRICHED_IP,
+        ALL_ENRICHED_TICKETS_IP
     ],
     'menu': [
         {'name': 'Overall', 'panel': ONION_PANEL_OVERALL},
         {'name': 'Projects', 'panel': ONION_PANEL_PROJECTS},
         {'name': 'Organizations', 'panel': ONION_PANEL_ORGS},
         {'name': 'Demographics', 'panel': DEMOGRAPHICS},
-        {'name': 'Affiliations', 'panel': AFFILIATIONS}
+        {'name': 'Affiliations', 'panel': AFFILIATIONS},
+        {'name': 'Contributors Growth', 'panel': CONTRIBUTIONS_GROWTH},
+        {'name': 'Organizational Diversity', 'panel': ORGANIZATIONAL_DIVERSITY},
+        {'name': 'Organizational Diversity by Domains', 'panel': ORGANIZATIONAL_DIVERSITY_BY_DOMAINS},
+        {'name': 'Engagement', 'panel': ENGAGEMENT_BY_CONTRIBUTIONS}
     ]
 }
 
@@ -246,7 +258,10 @@ class TaskPanels(Task):
             self.panels[COMMUNITY_SOURCE] = [ONION_PANEL_OVERALL, ONION_PANEL_PROJECTS,
                                              ONION_PANEL_ORGS, DEMOGRAPHICS, AFFILIATIONS,
                                              ONION_PANEL_OVERALL_IP, ONION_PANEL_PROJECTS_IP,
-                                             ONION_PANEL_ORGS_IP, DEMOGRAPHICS_IP, AFFILIATIONS_IP]
+                                             ONION_PANEL_ORGS_IP, DEMOGRAPHICS_IP, AFFILIATIONS_IP,
+                                             ENGAGEMENT_BY_CONTRIBUTIONS, CONTRIBUTIONS_GROWTH,
+                                             ORGANIZATIONAL_DIVERSITY, ORGANIZATIONAL_DIVERSITY_BY_DOMAINS,
+                                             ALL_ENRICHED_IP, ALL_ENRICHED_TICKETS_IP]
 
         if self.conf['panels'][KAFKA_SOURCE]:
             self.panels[KAFKA_SOURCE] = [KAFKA_PANEL, KAKFA_IP]


### PR DESCRIPTION
This code includes the OSPO panels (listed below) in the standard dashboards shipped with grimoirelab. Furthermore, the aliases.json file is updated to automatically set the alias needed to visualize their data.

- contributors_growth
- engagement_by_contributors
- organizational_diversity
- orgnizational_diversity_by_domains

Below, the snippet of the new community menu:
![captura_161](https://user-images.githubusercontent.com/6515067/70378539-b20c7f00-1921-11ea-912c-5509418ddf91.png)
