### PR TITLE
[config] Add `enrich_feelings` study

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ enriched_index = github2-issues_enriched
 sleep-for-rate = true
 category = issue
 no-archive = true (suggested)
-studies = [enrich_geolocation:user, enrich_geolocation:assignee, enrich_extra_data:github2] (optional)
+studies = [enrich_geolocation:user, enrich_geolocation:assignee, enrich_extra_data:github2, enrich_feelings] (optional)
 
 [enrich_geolocation:user] (optional)
 location_field = user_location
@@ -564,6 +564,10 @@ geolocation_field = assignee_geolocation
 
 [enrich_extra_data:github2]
 json_url = https://gist.githubusercontent.com/zhquan/bb48654bed8a835ab2ba9a149230b11a/raw/5eef38de508e0a99fa9772db8aef114042e82e47/bitergia-example.txt
+
+[enrich_feelings]
+attributes = [title, body]
+nlp_rest_url = http://localhost:2901
 ```
 ##### pull request
 - projects.json
@@ -586,7 +590,7 @@ enriched_index = github2-pull_enriched
 sleep-for-rate = true
 category = pull_request
 no-archive = true (suggested)
-studies = [enrich_geolocation:user, enrich_geolocation:assignee, enrich_extra_data:git] (optional)
+studies = [enrich_geolocation:user, enrich_geolocation:assignee, enrich_extra_data:git, enrich_feelings] (optional)
 
 [enrich_geolocation:user] (optional)
 location_field = user_location
@@ -598,6 +602,10 @@ geolocation_field = assignee_geolocation
 
 [enrich_extra_data:github2]
 json_url = https://gist.githubusercontent.com/zhquan/bb48654bed8a835ab2ba9a149230b11a/raw/5eef38de508e0a99fa9772db8aef114042e82e47/bitergia-example.txt
+
+[enrich_feelings]
+attributes = [title, body]
+nlp_rest_url = http://localhost:2901
 ```
 
 #### gitlab

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -564,7 +564,7 @@ class Config():
         studies = ("enrich_demography", "enrich_areas_of_code", "enrich_onion", "kafka_kip",
                    "enrich_pull_requests", "enrich_git_branches", "enrich_cocom_analysis",
                    "enrich_colic_analysis", "enrich_geolocation", "enrich_forecast_activity",
-                   "enrich_extra_data")
+                   "enrich_extra_data", "enrich_feelings")
 
         return studies
 


### PR DESCRIPTION
This PR addresses https://github.com/chaoss/grimoirelab/issues/258

This code adds the study `enrich_feelings` to th list of available studies in GrimoireLab.

The study can be set up via the setup.cfg as follows
```
[github2]
api-token = ...
raw_index = github_chaoss_crossminer
enriched_index = github_chaoss_crossminer_enriched
sleep-for-rate = true
no-archive = true
studies = [enrich_feelings]

[enrich_feelings]
attributes = [title, body]
nlp_rest_url = http://localhost:2901

[github2:prs]
api-token = ...
raw_index = github-prs_chaoss_crossminer
enriched_index = github-prs_chaoss_crossminer_enriched
sleep-for-rate = true
category = pull_request
no-archive = true
studies = [enrich_feelings]
```

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>