### PR TITLE
[config] Add support for `enrich_forecast_activity` study

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,9 @@ out_index = git-onion_enriched
 
 [enrich_extra_data:git]
 json_url = https://gist.githubusercontent.com/zhquan/bb48654bed8a835ab2ba9a149230b11a/raw/5eef38de508e0a99fa9772db8aef114042e82e47/bitergia-example.txt
+
+[enrich_forecast_activity]
+out_index = git_study_forecast
 ```
 #### github
 Issues and PRs from GitHub

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -563,7 +563,8 @@ class Config():
         # to have several backend entries with different configs
         studies = ("enrich_demography", "enrich_areas_of_code", "enrich_onion", "kafka_kip",
                    "enrich_pull_requests", "enrich_git_branches", "enrich_cocom_analysis",
-                   "enrich_colic_analysis", "enrich_geolocation", "enrich_extra_data")
+                   "enrich_colic_analysis", "enrich_geolocation", "enrich_forecast_activity",
+                   "enrich_extra_data")
 
         return studies
 


### PR DESCRIPTION
This code enables the support of the survival study in mordred.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>