### PR TITLE
[task_enrich] Fix name of github token

### DIFF
--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -127,8 +127,8 @@ class TaskEnrich(Task):
         github_token = None
         pair_programming = False
         node_regex = None
-        if 'github' in cfg and 'backend_token' in cfg['github']:
-            github_token = cfg['github']['backend_token']
+        if 'github' in cfg and 'api-token' in cfg['github']:
+            github_token = cfg['github']['api-token']
         if 'git' in cfg and 'pair-programming' in cfg['git']:
             pair_programming = cfg['git']['pair-programming']
         if 'jenkins' in cfg and 'node_regex' in cfg['jenkins']:


### PR DESCRIPTION
This code fixes the name of the github token, which is passed to ELK to retrieve the github username of
the git authors. Such information together with the email and name are stored in SortingHat as
`github-commit` source.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>