### PR TITLE
[panels] Upload github-comments dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ is stored. Furthermore, it also includes backend sections to set up the paramete
  * **kibiter_url** (str): Kibiter URL (**Required**)
  * **kibiter_version** (str: None): Kibiter version
  * **kafka** (bool: False): Include KIP section in dashboard
- * **github-repos** (bool: False): Enable GitHub repo stats menu. Note that if enabled, github:repo sections in the setup.cfg and projects.json should be declared
- * **gitlab-issues** (bool: False): Enable GitLab issues menu
- * **gitlab-merges** (bool: False): Enable GitLab merge requests menu
+ * **github-comments** (bool: False): Enable GitHub comments menu. Note that if enabled, the github2:issue and github2:pulls sections in the setup.cfg and projects.json should be declared
+ * **github-repos** (bool: False): Enable GitHub repo stats menu. Note that if enabled, the github:repo section in the setup.cfg and projects.json should be declared
+ * **gitlab-issues** (bool: False): Enable GitLab issues menu. Note that if enabled, the gitlab:issue section in the setup.cfg and projects.json should be declared
+ * **gitlab-merges** (bool: False): Enable GitLab merge requests menu. Note that if enabled, the gitlab:merge sections in the setup.cfg and projects.json should be declared
  * **mattermost** (bool: False): Enable Mattermost menu
  * **code-license** (bool: False): Enable code license menu. Note that if enabled, colic sections in the setup.cfg and projects.json should be declared
  * **code-complexity** (bool: False): Enable code complexity menu. Note that if enabled, cocom sections in the setup.cfg and projects.json should be declared

--- a/aliases.json
+++ b/aliases.json
@@ -50,6 +50,14 @@
       "raw": ["github_repositories-raw"],
       "enrich": ["github_repositories"]
   },
+  "github2:issue": {
+      "raw": ["github2_issues-raw"],
+      "enrich": ["github2_issues"]
+  },
+  "github2:pull": {
+      "raw": ["github2_pull_requests-raw"],
+      "enrich": ["github2_pull_requests"]
+  },
   "github": {
       "raw": ["github-raw"],
       "enrich": ["github_issues", "github_issues_enrich", "issues_closed",

--- a/doc/config.md
+++ b/doc/config.md
@@ -41,9 +41,10 @@ Use python mordred/config.py to generate it.
  * **kibiter_url** (str): Kibiter URL (**Required**)
  * **kibiter_version** (str: None): Kibiter version
  * **kafka** (bool: False): Include KIP section in dashboard
- * **github-repos** (bool: False): Enable GitHub repo stats menu
- * **gitlab-issues** (bool: False): Enable GitLab issues menu
- * **gitlab-merges** (bool: False): Enable GitLab merge requests menu
+ * **github-comments** (bool: False): Enable GitHub comments menu. Note that if enabled, the github2:issue and github2:pulls sections in the setup.cfg and projects.json should be declared
+ * **github-repos** (bool: False): Enable GitHub repo stats menu. Note that if enabled, the github:repo section in the setup.cfg and projects.json should be declared
+ * **gitlab-issues** (bool: False): Enable GitLab issues menu. Note that if enabled, the gitlab:issue section in the setup.cfg and projects.json should be declared
+ * **gitlab-merges** (bool: False): Enable GitLab merge requests menu. Note that if enabled, the gitlab:merge sections in the setup.cfg and projects.json should be declared
  * **mattermost** (bool: False): Enable Mattermost menu
  * **strict** (bool: True): Enable strict panels loading
  * **contact** (str: None): Support repository URL

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -330,6 +330,12 @@ class Config():
                     "type": bool,
                     "description": "Enable kafka menu"
                 },
+                "github-comments": {
+                    "optional": True,
+                    "default": False,
+                    "type": bool,
+                    "description": "Enable GitHub comments menu"
+                },
                 "github-repos": {
                     "optional": True,
                     "default": False,

--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -102,6 +102,23 @@ COMMUNITY_MENU = {
     ]
 }
 
+GITHUB_COMMENTS = "github-comments"
+GITHUB_ISSUE_COMMENTS_PANEL = "panels/json/github2_issues_comments_and_collaboration.json"
+GITHUB_ISSUE_COMMENTS_IP = "panels/json/github2_issues-index-pattern.json"
+GITHUB_PULL_COMMENTS_PANEL = "panels/json/github2_pull_requests_comments_and_collaboration.json"
+GITHUB_PULL_COMMENTS_IP = "panels/json/github2_pull_requests-index-pattern.json"
+
+GITHUB_COMMENTS_MENU = {
+    'name': 'GitHub Comments',
+    'source': GITHUB_COMMENTS,
+    'icon': 'default.png',
+    'index-patterns': [GITHUB_ISSUE_COMMENTS_IP, GITHUB_PULL_COMMENTS_IP],
+    'menu': [
+        {'name': 'Issues', 'panel': GITHUB_ISSUE_COMMENTS_PANEL},
+        {'name': 'Pull requests', 'panel': GITHUB_PULL_COMMENTS_PANEL}
+    ]
+}
+
 GITHUB_REPOS = "github-repos"
 GITHUB_REPOS_PANEL_OVERALL = "panels/json/github_repositories.json"
 GITHUB_REPOS_IP = "panels/json/github_repositories-index-pattern.json"
@@ -265,6 +282,10 @@ class TaskPanels(Task):
 
         if self.conf['panels'][KAFKA_SOURCE]:
             self.panels[KAFKA_SOURCE] = [KAFKA_PANEL, KAKFA_IP]
+
+        if self.conf['panels'][GITHUB_COMMENTS]:
+            self.panels[GITHUB_COMMENTS] = [GITHUB_ISSUE_COMMENTS_PANEL, GITHUB_PULL_COMMENTS_PANEL,
+                                            GITHUB_ISSUE_COMMENTS_IP, GITHUB_PULL_COMMENTS_IP]
 
         if self.conf['panels'][GITHUB_REPOS]:
             self.panels[GITHUB_REPOS] = [GITHUB_REPOS_PANEL_OVERALL, GITHUB_REPOS_IP]
@@ -494,6 +515,9 @@ class TaskPanelsMenu(Task):
                 logger.error(ex)
                 raise
 
+        if self.conf['panels'][GITHUB_COMMENTS]:
+            self.panels_menu.append(GITHUB_COMMENTS_MENU)
+
         if self.conf['panels'][GITHUB_REPOS]:
             self.panels_menu.append(GITHUB_REPOS_MENU)
 
@@ -533,7 +557,8 @@ class TaskPanelsMenu(Task):
         for entry in self.panels_menu:
             ds = entry['source']
             if ds in self.conf.keys() or ds in [COMMUNITY_SOURCE, KAFKA_SOURCE, GITLAB_ISSUES, GITLAB_MERGES,
-                                                MATTERMOST, GITHUB_REPOS, COCOM_SOURCE, COLIC_SOURCE]:
+                                                MATTERMOST, GITHUB_COMMENTS, GITHUB_REPOS,
+                                                COCOM_SOURCE, COLIC_SOURCE]:
                 active_ds.append(ds)
         logger.debug("Active data sources for menu: %s", active_ds)
 


### PR DESCRIPTION
This code provides the means to automatically upload the github comments dashboard, useful to understand the community interactions on issue and pull request comments.

The dashboard can be activated by setting `github-comments` to true in the section `panels` of the setup.cfg. Note that the setup.cfg should also include the sections `github2:pull` and `github2:issue`.
```
[panels]
kibiter_time_from= "now-2y"
kibiter_default_index= "git"
kibiter_url = http://admin:admin@localhost:5601
github-comments = true <-----

[github2:issue]
api-token = xxx
raw_index = github_chaoss
enriched_index = github_chaoss_180322_enriched_200123
sleep-for-rate = true
no-archive = true

[github2:pull]
api-token = xxx
raw_index = github-prs_chaoss
enriched_index = github-prs_chaoss_190830_enriched_200123
sleep-for-rate = true
category = pull_request
no-archive = true
```