### PR TITLE
[aliases] Handle complex aliases

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -1,162 +1,818 @@
 {
   "askbot": {
-      "raw": ["askbot-raw"],
-      "enrich": ["askbot", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "askbot-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "askbot"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "apache": {
-      "raw": ["apache"]
+    "raw": [
+      {
+        "alias": "apache"
+      }
+    ]
   },
   "bugzilla": {
-      "raw": ["bugzilla-raw"],
-      "enrich": ["bugzilla", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "bugzilla-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "bugzilla"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
   },
   "bugzillarest": {
-      "raw": ["bugzilla-raw"],
-      "enrich": ["bugzilla", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "bugzilla-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "bugzilla"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
   },
   "crates": {
-      "raw": ["crates-raw"],
-      "enrich": ["crate", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "crates-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "crate"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "confluence": {
-      "raw": ["confluence-raw"],
-      "enrich": ["confluence", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "confluence-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "confluence"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "discourse": {
-      "raw": ["discourse-raw"],
-      "enrich": ["discourse", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "discourse-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "discourse"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "dockerhub": {
-      "raw": ["dockerhub-raw"],
-      "enrich": ["dockerhub"]
+    "raw": [
+      {
+        "alias": "dockerhub-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "dockerhub"
+      }
+    ]
   },
   "finosmeetings": {
-      "raw": ["finosmeetings-raw"],
-      "enrich": ["finosmeetings", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "finosmeetings-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "finosmeetings"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "functest": {
-      "raw": ["functest-raw"],
-      "enrich": ["functest"]
+    "raw": [
+      {
+        "alias": "functest-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "functest"
+      }
+    ]
   },
   "gerrit": {
-      "raw": ["gerrit-raw"],
-      "enrich": ["gerrit", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "gerrit-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "finosmeetings"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "git": {
-      "raw": ["git-raw"],
-      "enrich": ["git", "git_author", "git_enrich", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "git-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "git"
+      },
+      {
+        "alias": "git_author"
+      },
+      {
+        "alias": "git_enrich"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "github:repo": {
-      "raw": ["github_repositories-raw"],
-      "enrich": ["github_repositories"]
+    "raw": [
+      {
+        "alias": "github_repositories-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github_repositories"
+      }
+    ]
+  },
+  "github2:issue": {
+    "raw": [
+      {
+        "alias": "github2_issues-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github2_issues"
+      },
+      {
+        "alias": "github2_pull_requests",
+        "filter": {
+          "terms": {
+            "issue_pull_request" : [
+              "true"
+            ]
+          }
+        }
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
+  },
+  "github2:pull": {
+    "raw": [
+      {
+        "alias": "github2_pull_requests-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github2_pull_requests"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "github": {
-      "raw": ["github-raw"],
-      "enrich": ["github_issues", "github_issues_enrich", "issues_closed",
-                 "issues_created", "issues_updated", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "github-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github_issues"
+      },
+      {
+        "alias": "github_issues_enrich"
+      },
+      {
+        "alias": "issues_closed"
+      },
+      {
+        "alias": "issues_created"
+      },
+      {
+        "alias": "issues_updated"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets",
+        "filter" : {
+              "terms" : {
+                "pull_request" : ["false"]
+              }
+            }
+      },
+      {
+        "alias": "github_issues_onion-src",
+        "filter" : {
+            "terms" : {
+            "pull_request" : [
+                "false"
+                ]
+            }
+        }
+      },
+      {
+        "alias": "github_prs_onion-src",
+        "filter" : {
+            "terms" : {
+            "pull_request" : [
+                "true"
+            ]
+          }
+        }
+      }
+    ]
   },
   "gitlab:issue": {
-      "raw": ["gitlab_issues-raw"],
-      "enrich": ["gitlab_issues", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "gitlab_issues-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "gitlab_issues"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
   },
   "gitlab:merge": {
-      "raw": ["gitlab_merge_requests-raw"],
-      "enrich": ["gitlab_merge_requests", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "gitlab_merge_requests-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "gitlab_merge_requests"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "google_hits": {
-      "raw": ["google-hits-raw"],
-      "enrich": ["google-hits"]
+    "raw": [
+      {
+        "alias": "google-hits-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "google-hits"
+      }
+    ]
   },
   "hyperkitty": {
-      "raw": ["hyperkitty-raw"],
-      "enrich": ["mbox", "kafka", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "hyperkitty-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "groupsio": {
-      "raw": ["groupsio-raw"],
-      "enrich": ["mbox", "kafka", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "groupsio-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "jenkins": {
-      "raw": ["jenkins-raw"],
-      "enrich": ["jenkins"]
+    "raw": [
+      {
+        "alias": "jenkins-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "jenkins"
+      }
+    ]
   },
   "jira": {
-      "raw": ["jira-raw"],
-      "enrich": ["jira", "jira_resolution_date", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "jira-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "jira"
+      },
+      {
+        "alias": "jira_resolution_date"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
   },
   "kitsune": {
-      "raw": ["kitsune-raw"],
-      "enrich": ["kitsune", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "kitsune-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "kitsune"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "mattermost": {
-      "raw": ["mattermost-raw"],
-      "enrich": ["mattermost", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "mattermost-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mattermost"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "mbox": {
-      "raw": ["mbox-raw"],
-      "enrich": ["mbox", "kafka", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "mbox-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "mediawiki": {
-      "raw": ["mediawiki-raw"],
-      "enrich": ["mediawiki", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "mediawiki-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mediawiki"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "meetup": {
-      "raw": ["meetup-raw"],
-      "enrich": ["meetup", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "meetup-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "meetup"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "mozillaclub": {
-      "raw": ["mozillaclub-raw"],
-      "enrich": ["mozillaclub", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "mozillaclub-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mozillaclub"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "nntp": {
-      "raw": ["nntp-raw"],
-      "enrich": ["mbox", "kafka", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "mozillaclub-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "phabricator": {
-      "raw": ["phabricator-raw"],
-      "enrich": ["phabricator", "maniphest", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "phabricator-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "phabricator"
+      },
+      {
+        "alias": "maniphest"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "pipermail": {
-      "raw": ["pipermail-raw"],
-      "enrich": ["mbox", "kafka", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "pipermail-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "mbox"
+      },
+      {
+        "alias": "kafka"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "puppetforge": {
-      "raw": ["puppetforge-raw"],
-      "enrich": ["puppetforge", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "puppetforge-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "puppetforge"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "redmine": {
-      "raw": ["redmine-raw"],
-      "enrich": ["redmine", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "redmine-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "redmine"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets"
+      }
+    ]
   },
   "remo": {
-      "raw": ["remo-raw"],
-      "enrich": ["remo", "remo-events", "remo-events_metadata__timestamp", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "remo-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "remo"
+      },
+      {
+        "alias": "remo-events"
+      },
+      {
+        "alias": "remo-events_metadata__timestamp"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "remo:activities": {
-      "raw": ["remo_activities-raw"],
-      "enrich": ["remo-activities", "remo-activities_metadata__timestamp", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "remo_activities-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "remo-activities"
+      },
+      {
+        "alias": "remo-activities_metadata__timestamp"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "rss": {
-      "raw": ["rss-raw"],
-      "enrich": ["rss", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "rss-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "rss"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "slack": {
-      "raw": ["slack-raw"],
-      "enrich": ["slack", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "slack-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "slack"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "stackexchange": {
-      "raw": ["stackexchange-raw"],
-      "enrich": ["stackoverflow", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "stackexchange-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "stackoverflow"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "supybot": {
-      "raw": ["supybot-raw"],
-      "enrich": ["supybot", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "supybot-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "supybot"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "telegram": {
-      "raw": ["telegram-raw"],
-      "enrich": ["telegram", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "telegram-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "telegram"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   },
   "twitter": {
-      "raw": ["twitter-raw"],
-      "enrich": ["twitter", "affiliations", "all_enriched"]
+    "raw": [
+      {
+        "alias": "twitter-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "twitter"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This code reshapes the aliases.json, which now is able to handle complex aliases. The new format
allows to define a list of aliases with/without filters. An example of a new alias is provided below:
```
"github2:issue": {
    "raw": [
      {
        "alias": "github2_issues-raw"
      }
    ],
    "enrich": [
      {
        "alias": "github2_issues"
      },
      {
        "alias": "github2_pull_requests",
        "filter": {
          "terms": {
            "issue_pull_request" : [
              "true"
            ]
          }
        }
      },
      {
        "alias": "affiliations"
      },
      {
        "alias": "all_enriched"
      }
    ]
  },
```

Addresses to: https://github.com/chaoss/grimoirelab-sirmordred/issues/388
Related to: https://github.com/chaoss/grimoirelab-elk/pull/771