### PR TITLE
[sirmordred] Remove support for github commit

### DIFF
--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -213,13 +213,6 @@ class Task():
                                      clean, enrich_backend)
         enrich_backend.set_elastic(elastic_enrich)
 
-        if 'github' in self.conf.keys() and \
-            'backend_token' in self.conf['github'].keys() and \
-            self.get_backend(self.backend_section) == "git":
-
-            gh_token = self.conf['github']['backend_token']
-            enrich_backend.set_github_token(gh_token)
-
         if self.db_unaffiliate_group:
             enrich_backend.unaffiliated_group = self.db_unaffiliate_group
 

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -124,11 +124,10 @@ class TaskEnrich(Task):
             ElasticSearch.max_items_bulk = cfg['general']['bulk_size']
 
         no_incremental = False
+        # not used due to https://github.com/chaoss/grimoirelab-elk/pull/773
         github_token = None
         pair_programming = False
         node_regex = None
-        if 'github' in cfg and 'backend_token' in cfg['github']:
-            github_token = cfg['github']['backend_token']
         if 'git' in cfg and 'pair-programming' in cfg['git']:
             pair_programming = cfg['git']['pair-programming']
         if 'jenkins' in cfg and 'node_regex' in cfg['jenkins']:


### PR DESCRIPTION
This code removes the support to include author and committer information extracted from github commits, when enriching git data. Thus, the code used to initialize the github token needed to query the API is removed.

Review together with https://github.com/chaoss/grimoirelab-elk/pull/773
Deprecates https://github.com/chaoss/grimoirelab-sirmordred/pull/384