### PR TITLE
[travis] Support python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
 
 sudo: false
 


### PR DESCRIPTION
This code extends the CI tests to python 3.7

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>