### PR TITLE
[aliases.json] Remove old github2 aliases

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -262,14 +262,6 @@
       }
     ]
   },
-  "github2:issue": {
-      "raw": ["github2_issues-raw"],
-      "enrich": ["github2_issues"]
-  },
-  "github2:pull": {
-      "raw": ["github2_pull_requests-raw"],
-      "enrich": ["github2_pull_requests"]
-  },
   "github": {
     "raw": [
       {


### PR DESCRIPTION
This code removes the old aliases set for github2 indixes.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>