### PR TITLE
Inlcude pipes option in the configuration

### DIFF
--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -37,7 +37,7 @@ class Task():
 
     NO_BACKEND_FIELDS = ['enriched_index', 'raw_index', 'es_collection_url',
                          'collect', 'pair-programming', 'fetch-archive', 'studies',
-                         'node_regex']
+                         'node_regex', 'pipes']
     PARAMS_WITH_SPACES = ['blacklist-jobs']
 
     def __init__(self, config):

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -96,6 +96,10 @@ class TaskRawDataCollection(Task):
         if 'fetch-archive' in cfg[self.backend_section] and cfg[self.backend_section]['fetch-archive']:
             fetch_archive = True
 
+        pipes = None
+        if 'pipes' in cfg[self.backend_section]:
+            pipes = [pipe for pipe in self.conf[self.backend_section]['pipes'] if pipe.strip() != ""]
+
         # repos could change between executions because changes in projects
         repos = TaskProjects.get_repos_by_backend_section(self.backend_section)
 
@@ -135,7 +139,7 @@ class TaskRawDataCollection(Task):
                 error_msg = feed_backend(es_col_url, clean, fetch_archive, backend, backend_args,
                                          cfg[ds]['raw_index'], cfg[ds]['enriched_index'], project,
                                          es_aliases=es_aliases, projects_json_repo=repo,
-                                         repo_labels=repo_labels)
+                                         repo_labels=repo_labels, pipes=pipes)
                 error = {
                     'backend': backend,
                     'repo': repo,


### PR DESCRIPTION
This PR allows to use pipes for items that are retrieved from Perceval

Example configuration:
```
[github]
...
pipes = [TestPipe]
```

Tests are pending