### PR TITLE
Fix error #401 with cache file that is not removed for healthchecks

### DIFF
--- a/docker/stage
+++ b/docker/stage
@@ -16,4 +16,6 @@ echo "Starting two workers: collect and update tasks"
 (arthurw -g -d redis://$REDIS/8 > $HOME_DIR/logs/worker-collect.log 2>&1) &
 (arthurw -g -d redis://$REDIS/8 update > $HOME_DIR/logs/worker-update.log 2>&1) &
 
+rm -f /tmp/.mordred_healthcheck
+
 sirmordred -c $HOME_DIR/conf/setup.cfg


### PR DESCRIPTION
In order to solve the error the file used as cache for the healtchcheck is removed when the container is restarted. This way an unhealthy container can calculate the status from scratch after the reboot.

Fixes: #401
Signed-off-by: Luis Cañas-Díaz <lcanas@bitergia.com>