### PR TITLE
[doc] Add instructions to use dockersmells and dockerdeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,48 @@ raw_index = dockerhub_raw
 enriched_index = dockerhub_enriched
 no-archive = true (suggested)
 ```
+#### dockerdeps
+Dependencies extracted from Docker files. Requires https://github.com/crossminer/crossJadolint
+- projects.json
+```
+{
+    "Chaoss": {
+        "dockerdeps": [
+            "https://github.com/chaoss/grimoirelab"
+        ]
+    }
+}
+```
+- setup.cfg
+```
+[dockerdeps]
+raw_index = dockerdeps_raw
+enriched_index = dockerdeps_enrich
+category = code_dependencies_jadolint
+exec-path = <jadolint-local-path>/jadolint.jar
+in-paths = [Dockerfile, Dockerfile-full, Dockerfile-secured, Dockerfile-factory, Dockerfile-installed]
+```
+#### dockersmells
+Smells extracted from Docker files. Requires https://github.com/crossminer/crossJadolint 
+- projects.json
+```
+{
+    "Chaoss": {
+        "dockersmells": [
+            "https://github.com/chaoss/grimoirelab"
+        ]
+    }
+}
+```
+- setup.cfg
+```
+[dockersmells]
+raw_index = dockersmells_raw
+enriched_index = dockersmells_enrich
+category = code_quality_jadolint
+exec-path = <jadolint-local-path>/jadolint.jar
+in-paths = [Dockerfile, Dockerfile-full, Dockerfile-secured, Dockerfile-factory, Dockerfile-installed]
+```
 #### functest
 Tests from functest
 - projects.json


### PR DESCRIPTION
This code updates the README to include examples of dockersmells and dockerdeps used to collect dependencies and smells from Docker files.

Related to https://github.com/chaoss/grimoirelab/issues/262