### PR TITLE
[aliases] Fix supybot alias `irc` instead of `supybot`

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -764,12 +764,12 @@
   "supybot": {
     "raw": [
       {
-        "alias": "supybot-raw"
+        "alias": "irc-raw"
       }
     ],
     "enrich": [
       {
-        "alias": "supybot"
+        "alias": "irc"
       },
       {
         "alias": "affiliations"

--- a/tests/aliases.json
+++ b/tests/aliases.json
@@ -144,8 +144,8 @@
       "enrich": ["stackoverflow", "affiliations"]
   },
   "supybot": {
-      "raw": ["supybot-raw"],
-      "enrich": ["supybot", "affiliations"]
+      "raw": ["irc-raw"],
+      "enrich": ["irc", "affiliations"]
   },
   "telegram": {
       "raw": ["telegram-raw"],


### PR DESCRIPTION
Test data has been updated accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>