### PR TITLE
Removed faulty parameter from utils/setup.cfg

### DIFF
--- a/utils/setup.cfg
+++ b/utils/setup.cfg
@@ -54,8 +54,6 @@ unaffiliated_group = Unknown
 autoprofile = [customer,git,github]
 matching = [email]
 sleep_for = 120
-# sleep_for = 1800
-bots_names = [Beloved Bot]
 
 [panels]
 kibiter_time_from= "now-30y"


### PR DESCRIPTION
Removed two parameters from the example setup.cfg file.