### PR TITLE
[task_panels] Upload panels from the sigils module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ redis==3.0.0
 -e git+https://github.com/chaoss/grimoirelab-perceval-mozilla/#egg=grimoirelab-perceval-mozilla
 -e git+https://github.com/Bitergia/grimoirelab-perceval-finos/#egg=grimoirelab-perceval-finos
 -e git+https://github.com/chaoss/grimoirelab-kingarthur/#egg=grimoirelab-kingarthur
+-e git+https://github.com/chaoss/grimoirelab-sigils/#egg=grimoirelab-sigils

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(name="sirmordred",
       install_requires=[
           'grimoire-elk>=0.32',
           'kidash>=0.4.13',
+          'grimoirelab-panels>=0.0.7',
           'sortinghat>=0.7',
           'kingarthur>=0.1.12',
           'elasticsearch==6.3.1',

--- a/tests/test_task_panels.py
+++ b/tests/test_task_panels.py
@@ -82,7 +82,8 @@ class TestTaskPanels(unittest.TestCase):
         config = Config(CONF_FILE)
         task = TaskPanels(config)
 
-        task.create_dashboard(None, data_sources=["stackexchange"])
+        panel_file = 'panels/json/stackoverflow.json'
+        task.create_dashboard(panel_file, data_sources=["stackexchange"])
 
     @httpretty.activate
     def test_create_dashboard_multi_ds_kibiter_6(self):


### PR DESCRIPTION
This code fixes the way the panels are loaded due to the recent change on kidash (commit:
https://github.com/chaoss/grimoirelab-kidash/commit/e8795023b31df726850b32e3f019a933ea614d5a) that has removed the dependency with sigils.

Now the task panels takes care of building the panels path, which consists of the sigils module plus the name of panels.

Dependencies in the requirements.txt and setup.py have been updated to include sigils.

Tests have been updated accordingly.

Fixes #410 