### PR TITLE
added color logging facility in micro.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+colorlog==4.1.0
 elasticsearch==6.3.1
 elasticsearch-dsl==6.3.1
 file-read-backwards==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ setup(name="sirmordred",
           'sortinghat>=0.7',
           'elasticsearch==6.3.1',
           'elasticsearch-dsl==6.3.1',
-          'file-read-backwards==2.0.0'
+          'file-read-backwards==2.0.0',
+          'colorlog==4.1.0'
       ],
       scripts=[
           'bin/sirmordred',

--- a/utils/micro.py
+++ b/utils/micro.py
@@ -22,6 +22,7 @@
 
 import argparse
 import logging
+import colorlog
 import sys
 
 from sirmordred.config import Config
@@ -31,9 +32,9 @@ from sirmordred.task_enrich import TaskEnrich
 from sirmordred.task_panels import TaskPanels, TaskPanelsMenu
 from sirmordred.task_projects import TaskProjects
 
-
-DEBUG_LOG_FORMAT = "[%(asctime)s - %(name)s - %(levelname)s] - %(message)s"
-INFO_LOG_FORMAT = "%(asctime)s %(message)s"
+DEBUG_LOG_FORMAT = "\033[1m %(log_color)s [%(asctime)s - %(name)s - %(levelname)s] - %(message)s"
+INFO_LOG_FORMAT = "\033[1m %(log_color)s %(asctime)s %(message)s"
+LOG_COLORS = {'DEBUG': 'white', 'INFO': 'cyan', 'WARNING': 'yellow', 'ERROR': 'red', 'CRITICAL': 'red,bg_white'}
 
 
 def micro_mordred(cfg_path, backend_sections, raw, identities_load, identities_merge, enrich, panels):
@@ -143,11 +144,18 @@ def config_logging(debug):
     """Config logging level output output"""
 
     if debug:
+        format = DEBUG_LOG_FORMAT
         logging.basicConfig(level=logging.DEBUG,
                             format=DEBUG_LOG_FORMAT)
         logging.debug("Debug mode activated")
     else:
+        format = INFO_LOG_FORMAT
         logging.basicConfig(level=logging.INFO, format=INFO_LOG_FORMAT)
+
+    # Setting the color scheme into the root logger
+    stream = logging.root.handlers[0]
+    formatter = colorlog.ColoredFormatter(fmt=format, log_colors=LOG_COLORS)
+    stream.setFormatter(formatter)
 
     # ES logger is set to INFO since, it produces a really verbose output if set to DEBUG
     logging.getLogger('elasticsearch').setLevel(logging.INFO)
@@ -200,7 +208,6 @@ def get_params():
 
 
 if __name__ == '__main__':
-
     args = get_params()
     config_logging(args.debug)
 


### PR DESCRIPTION
Signed-off-by: abhiandthetruth <abhiandthetruth@gmail.com>
Fixes Partially #423 
@valeriocos please review. 
Just wanted the opinion before porting the new logging system to sirmordred binary. I have currently added the logging support only for micro.py. Please use it (you may copy the code directly from here it's small, or use my branch) and review. You may try it for different scenarios like when there are several errors and look if the readability and user experience is improved. A new dependency `colorlog` is added which I am concerned of. I tried several ways but the solutions were either very large or not extensible. I found this one the most compact and suitable.
If the coloring is too subjective we can also add a argument maybe `--enhanced-log`, leaving it to the user whether to use it or not. 
If you ask me, this really helps in reading the logs. Thanks :).