### PR TITLE
[micromordred] Replace actual api-token

### DIFF
--- a/utils/setup.cfg
+++ b/utils/setup.cfg
@@ -136,14 +136,14 @@ no-archive = true
 [gitlab:issue]
 raw_index = test_gitlab-issue-raw
 enriched_index = test_gitlab-issue
-api-token = nsTwsxkTbnoJBbY3pC43
+api-token = xxxx
 no-archive = true
 sleep-for-rate = true
 
 [gitlab:merge]
 raw_index = test_gitlab-merge-raw
 enriched_index = test_gitlab-merge
-api-token = nsTwsxkTbnoJBbY3pC43
+api-token = xxxx
 no-archive = true
 category = merge_request
 sleep-for-rate = true


### PR DESCRIPTION
This commit replaces actual api-token in
Gitlab config with a place holder xxxx

Signed-off-by: animesh <animuz111@gmail.com>