### PR TITLE
[micro mordred]added logging to file support for micro.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1288,12 +1288,16 @@ Micro Mordred is located in the [/utils](https://github.com/chaoss/grimoirelab-s
 --panels: activate panels task
 
 --cfg: path of the onfiguration file
+
 --backends: list of cfg sections where the active tasks will be executed
+
+--logs-dir: single parameter denoting the path of folder in which logs are to be stored
 ```
 
 Examples of possible executions are shown below:
 ```
 cd .../grimoirelab-sirmordred/utils/
-micro.py --raw --enrich --cfg ./setup.cfg --backends git #  execute the Raw and Enrich tasks for the Git cfg section
+micro.py --raw --enrich --cfg ./setup.cfg --backends git # execute the Raw and Enrich tasks for the Git cfg section
 micro.py --panels # execute the Panels task to load the Sigils panels to Kibiter
+micro.py --raw --enrich --debug --cfg ./setup.cfg --backends groupsio --logs-dir logs # execute the raw and enriched tasks for the groupsio cfg section with debug mode on and logs being saved in the folder logs in the same directory as micro.py
 ``` 


### PR DESCRIPTION
Signed-off-by: abhiandthetruth <abhiandthetruth@gmail.com>
Added logging to file support for micro mordred. Now devs can use the `--logs-dir` argument followed by the directory name to enable logging into file. This enables easy sharing of logs for debugging purposes. Please review.
The logs are currently being appended to the same file. We can change that behaviour to either of the below:
* Create a new log file for every execution. In this case the name of the file will contain the timestamp of the corresponding execution.
* Simply replace the content of the old file when a new execution takes place. 
Same applies for sirmordred.
Which one should I go for?