### PR TITLE
[sirmordred] Remove duplicate call of execute_batch_tasks

### DIFF
--- a/sirmordred/sirmordred.py
+++ b/sirmordred/sirmordred.py
@@ -323,9 +323,6 @@ class SirMordred:
                     self.execute_batch_tasks(all_tasks_cls,
                                              sleep_for,
                                              self.conf['general']['min_update_delay'])
-                    self.execute_batch_tasks(all_tasks_cls,
-                                             sleep_for,
-                                             self.conf['general']['min_update_delay'])
                     break
                 else:
                     self.execute_nonstop_tasks(all_tasks_cls)


### PR DESCRIPTION
This PR removes the duplicate call of `execute_batch_tasks` function in `sirmordred.py` .
Fix #435 .
Signed-off-by: LinHaiming <lhming23@outlook.com>