### PR TITLE
Make anonymization optional for each backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ new data sources, thus you need to manually delete the dashboards `Data Status` 
 * **raw_index** (str: None): Index name in which to store the raw items (**Required**)
 * **enriched_index** (str: None): Index name in which to store the enriched items (**Required**)
 * **studies** (list: []): List of studies to be executed
+* **anonymize** (bool: False): enable/disable anonymization of personal user information
 * **backend-param-1**: ..
 * **backend-param-2**: ..
 * **backend-param-n**: ..

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -36,8 +36,8 @@ class Task():
     """ Basic class shared by all tasks """
 
     NO_BACKEND_FIELDS = ['enriched_index', 'raw_index', 'es_collection_url',
-                         'collect', 'pair-programming', 'fetch-archive', 'studies',
-                         'node_regex']
+                         'collect', 'pair-programming', 'fetch-archive',
+                         'studies', 'node_regex', 'anonymize']
     PARAMS_WITH_SPACES = ['blacklist-jobs']
 
     def __init__(self, config):

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -82,6 +82,8 @@ class TaskRawDataCollection(Task):
         if 'fetch-archive' in cfg[self.backend_section] and cfg[self.backend_section]['fetch-archive']:
             fetch_archive = True
 
+        anonymize = 'anonymize' in cfg[self.backend_section] and cfg[self.backend_section]['anonymize']
+
         # repos could change between executions because changes in projects
         repos = TaskProjects.get_repos_by_backend_section(self.backend_section)
 
@@ -121,7 +123,7 @@ class TaskRawDataCollection(Task):
                 error_msg = feed_backend(es_col_url, clean, fetch_archive, backend, backend_args,
                                          cfg[ds]['raw_index'], cfg[ds]['enriched_index'], project,
                                          es_aliases=es_aliases, projects_json_repo=repo,
-                                         repo_labels=repo_labels)
+                                         repo_labels=repo_labels, anonymize=anonymize)
                 error = {
                     'backend': backend,
                     'repo': repo,


### PR DESCRIPTION
We need a way to anonymize the personal information that comes from Perceval: names, emails and information that may be related to the users of each backend must be hidden.

The information stored in the Elasticsearch indexes should only be identifiers that cannot be related directly with the user.

In this merge request, information related with the users is hashed or removed.

You can set the parameter `anonymize` to true in the sirmordred configuration:
```
[git]
...
anonymize = true

[github]
...
filter-classified = true
anonymize = true

[gitlab]
...
anonymize = true

[meetup]
...
anonymize = true
```

Related with issues https://github.com/chaoss/grimoirelab-sirmordred/issues/443 and https://github.com/chaoss/grimoirelab-elk/issues/822

Related with pull request: https://github.com/chaoss/grimoirelab-elk/pull/823

Test are needed