### PR TITLE
[Getting-started] Update kibiter version to 6.1.4-3

### DIFF
--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -96,7 +96,7 @@ services:
 
     kibiter:
       restart: on-failure:5
-      image: bitergia/kibiter:optimized-v6.1.4-4
+      image: bitergia/kibiter:optimized-v6.1.4-3
       environment:
         - PROJECT_NAME=Demo
         - NODE_OPTIONS=--max-old-space-size=1000


### PR DESCRIPTION
This code updates the kibiter image used in the docker-compose to 6.1.4-3, since the network plugin
isn't loaded in the current version.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>