### PR TITLE
Remove user and password parameter from Elasticsearch section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,12 @@ new data sources, thus you need to manually delete the dashboards `Data Status` 
 
 ### [es_collection] 
 
- * **password** (str: None): Password for connection to Elasticsearch
  * **url** (str: http://172.17.0.1:9200): Elasticsearch URL (**Required**)
- * **user** (str: None): User for connection to Elasticsearch
 ### [es_enrichment] 
 
  * **autorefresh** (bool: True): Execute the autorefresh of identities
  * **autorefresh_interval** (int: 2): Time interval (days) to autorefresh identities
- * **password** (str: None): Password for connection to Elasticsearch
  * **url** (str: http://172.17.0.1:9200): Elasticsearch URL (**Required**)
- * **user** (str: None): User for connection to Elasticsearch
 ### [general] 
 
  * **bulk_size** (int: 1000): Number of items to write in Elasticsearch using bulk operations
@@ -732,7 +728,7 @@ replaced by `%2F`. For instance, for a repository with a structure similar to th
 ```
 {
     "Chaoss": {
-        "gitlab:issues": [
+        "gitlab:issue": [
             "https://gitlab.com/Molly/first",
             "https://gitlab.com/Molly/lab%2Fsecond"
         ]

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -210,18 +210,6 @@ class Config():
         # Config provided by tasks
         params_collection = {
             "es_collection": {
-                "password": {
-                    "optional": True,
-                    "default": None,
-                    "type": str,
-                    "description": "Password for connection to Elasticsearch"
-                },
-                "user": {
-                    "optional": True,
-                    "default": None,
-                    "type": str,
-                    "description": "User for connection to Elasticsearch"
-                },
                 "url": {
                     "optional": False,
                     "default": "http://172.17.0.1:9200",
@@ -250,18 +238,6 @@ class Config():
                     "default": 2,
                     "type": int,
                     "description": "Set time interval (days) for autorefresh identities"
-                },
-                "user": {
-                    "optional": True,
-                    "default": None,
-                    "type": str,
-                    "description": "User for connection to Elasticsearch"
-                },
-                "password": {
-                    "optional": True,
-                    "default": None,
-                    "type": str,
-                    "description": "Password for connection to Elasticsearch"
                 }
             }
         }


### PR DESCRIPTION
This commit removes user and password from the documentation in Elasticsearch section because it is not used.

It also fixes a typo in Gitlab section

Q: Should we remove user and password from https://github.com/chaoss/grimoirelab-sirmordred/blob/master/sirmordred/config.py#L213?