### PR TITLE
[tests] Remove user/password from es_enrichment section

### DIFF
--- a/tests/archives-test.cfg
+++ b/tests/archives-test.cfg
@@ -36,8 +36,6 @@ url = http://localhost:9200
 [es_enrichment]
 url = http://localhost:9200
 # url = https://admin:admin@localhost:9200
-user =
-password =
 autorefresh = false
 
 [sortinghat]


### PR DESCRIPTION
This code updates the archives-test.cfg to remove the user and password params in the es_enrichment section.