### PR TITLE
[mordred] Add support for github events

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ new data sources, thus you need to manually delete the dashboards `Data Status` 
  * **kibiter_version** (str: None): Kibiter version
  * **kafka** (bool: False): Include KIP section in dashboard
  * **github-comments** (bool: False): Enable GitHub comments menu. Note that if enabled, the github2:issue and github2:pull sections in the setup.cfg and projects.json should be declared
+ * **github-events** (bool: False): Enable GitHub events menu. Note that if enabled, the github:event section in the setup.cfg and projects.json should be declared
  * **github-repos** (bool: False): Enable GitHub repo stats menu. Note that if enabled, the github:repo section in the setup.cfg and projects.json should be declared
  * **gitlab-issues** (bool: False): Enable GitLab issues menu. Note that if enabled, the gitlab:issue section in the setup.cfg and projects.json should be declared
  * **gitlab-merges** (bool: False): Enable GitLab merge requests menu. Note that if enabled, the gitlab:merge sections in the setup.cfg and projects.json should be declared
@@ -631,6 +632,36 @@ studies = [enrich_extra_data:github]
 [enrich_extra_data:github]
 json_url = https://gist.githubusercontent.com/zhquan/bb48654bed8a835ab2ba9a149230b11a/raw/5eef38de508e0a99fa9772db8aef114042e82e47/bitergia-example.txt
 ```
+#### githubql [&uarr;](#supported-data-sources-)
+Events from GitHub
+
+The corresponding dashboards can be automatically uploaded by setting `github-events`
+to `true` in the `panels` section within the `setup.cfg`
+
+- projects.json
+```
+{
+    "Chaoss": {
+        "githubql": [
+            "https://github.com/chaoss/grimoirelab-toolkit"
+        ]
+    }
+}
+```
+- setup.cfg
+```
+[panels]
+github-events = true
+
+[githubql]
+raw_index = github_event_raw
+enriched_index = github_event_enriched
+api-token = xxxxx
+sleep-for-rate = true
+sleep-time = "300" (optional)
+no-archive = true (suggested)
+```
+
 #### github2 [&uarr;](#supported-data-sources-)
 Comments from GitHub
 

--- a/aliases.json
+++ b/aliases.json
@@ -204,6 +204,18 @@
       }
     ]
   },
+  "githubql": {
+    "raw": [
+      {
+        "alias": "github_events-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github_events"
+      }
+    ]
+  },
   "github:repo": {
     "raw": [
       {

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -292,6 +292,12 @@ class Config():
                     "type": bool,
                     "description": "Enable GitHub comments menu"
                 },
+                "github-events": {
+                    "optional": True,
+                    "default": False,
+                    "type": bool,
+                    "description": "Enable GitHub events menu"
+                },
                 "github-repos": {
                     "optional": True,
                     "default": False,

--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -120,6 +120,20 @@ GITHUB_COMMENTS_MENU = {
     ]
 }
 
+GITHUB_EVENTS = "github-events"
+GITHUB_CLOSED_EVENTS_PANEL = "panels/json/github_events_closed.json"
+GITHUB_CLOSED_EVENTS_IP = "panels/json/github_events-index-pattern.json"
+
+GITHUB_EVENTS_MENU = {
+    'name': 'GitHub Events',
+    'source': GITHUB_EVENTS,
+    'icon': 'default.png',
+    'index-patterns': [GITHUB_CLOSED_EVENTS_IP],
+    'menu': [
+        {'name': 'Closed events', 'panel': GITHUB_CLOSED_EVENTS_PANEL}
+    ]
+}
+
 GITHUB_REPOS = "github-repos"
 GITHUB_REPOS_PANEL_OVERALL = "panels/json/github_repositories.json"
 GITHUB_REPOS_IP = "panels/json/github_repositories-index-pattern.json"
@@ -292,6 +306,9 @@ class TaskPanels(Task):
         if self.conf['panels'][GITHUB_COMMENTS]:
             self.panels[GITHUB_COMMENTS] = [GITHUB_ISSUE_COMMENTS_PANEL, GITHUB_PULL_COMMENTS_PANEL,
                                             GITHUB_ISSUE_COMMENTS_IP, GITHUB_PULL_COMMENTS_IP]
+
+        if self.conf['panels'][GITHUB_EVENTS]:
+            self.panels[GITHUB_EVENTS] = [GITHUB_CLOSED_EVENTS_PANEL, GITHUB_CLOSED_EVENTS_IP]
 
         if self.conf['panels'][GITHUB_REPOS]:
             self.panels[GITHUB_REPOS] = [GITHUB_REPOS_PANEL_OVERALL, GITHUB_REPOS_IP]
@@ -525,6 +542,9 @@ class TaskPanelsMenu(Task):
         if self.conf['panels'][GITHUB_COMMENTS]:
             self.panels_menu.append(GITHUB_COMMENTS_MENU)
 
+        if self.conf['panels'][GITHUB_EVENTS]:
+            self.panels_menu.append(GITHUB_EVENTS_MENU)
+
         if self.conf['panels'][GITHUB_REPOS]:
             self.panels_menu.append(GITHUB_REPOS_MENU)
 
@@ -564,7 +584,7 @@ class TaskPanelsMenu(Task):
         for entry in self.panels_menu:
             ds = entry['source']
             if ds in self.conf.keys() or ds in [COMMUNITY_SOURCE, KAFKA_SOURCE, GITLAB_ISSUES, GITLAB_MERGES,
-                                                MATTERMOST, GITHUB_COMMENTS, GITHUB_REPOS,
+                                                MATTERMOST, GITHUB_COMMENTS, GITHUB_REPOS, GITHUB_EVENTS,
                                                 COCOM_SOURCE, COLIC_SOURCE]:
                 active_ds.append(ds)
         logger.debug("Active data sources for menu: %s", active_ds)


### PR DESCRIPTION
This code allows to upload the dashboard about github events using the param `github-events`, which must be set to true within the section `panels`.

Alias file has been updated accordingly.
Documentation has been updated accordingly.