### PR TITLE
[doc-git] Add parameter `run_month_days` in `enrich_git_branches`

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ studies = [enrich_demography:git, enrich_git_branches:git, enrich_areas_of_code:
 [enrich_demography:git] (optional)
 
 [enrich_git_branches:git] (optional)
+run_month_days = [1, 23] (optional)
 
 [enrich_areas_of_code:git] (optional)
 in_index = git_raw


### PR DESCRIPTION
This parameter set which days of the month the
`enrich_git_branches` study will run.

Signed-off-by: Quan Zhou <quan@bitergia.com>