### PR TITLE
[sirmordred] Remove credentials from private URLs

### DIFF
--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,1 +1,1 @@
-httpretty==0.8.6
+httpretty>=0.9.6

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -60,7 +60,7 @@ class Task():
 
     @staticmethod
     def anonymize_url(url):
-        anonymized = re.sub('^http.*@', 'http://', url)
+        anonymized = re.sub('://.*@', '://', url)
 
         return anonymized
 

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -111,7 +111,7 @@ class TaskRawDataCollection(Task):
             url = p2o_args['url']
             backend_args = self._compose_perceval_params(self.backend_section, repo)
             logger.debug(backend_args)
-            logger.info('[%s] collection starts for %s', self.backend_section, repo)
+            logger.info('[%s] collection starts for %s', self.backend_section, self.anonymize_url(repo))
             es_col_url = self._get_collection_url()
             ds = self.backend_section
             backend = self.get_backend(self.backend_section)
@@ -136,7 +136,7 @@ class TaskRawDataCollection(Task):
                              "Using the backend_args: %s " % (ds, url, str(backend_args)))
                 traceback.print_exc()
                 raise DataCollectionError('Failed to collect data from %s' % url)
-            logger.info('[%s] collection finished for %s', self.backend_section, repo)
+            logger.info('[%s] collection finished for %s', self.backend_section, self.anonymize_url(repo))
 
         t3 = time.time()
         spent_time = time.strftime("%H:%M:%S", time.gmtime(t3 - t2))

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -165,7 +165,7 @@ class TaskEnrich(Task):
                     self.conf[self.backend_section]['studies']:
                 studies_args = self.__load_studies()
 
-            logger.info('[%s] enrichment starts for %s', self.backend_section, repo)
+            logger.info('[%s] enrichment starts for %s', self.backend_section, self.anonymize_url(repo))
             es_enrich_aliases = self.select_aliases(cfg, self.backend_section)
 
             try:
@@ -206,7 +206,7 @@ class TaskEnrich(Task):
                 logger.error("Exception: %s", ex)
                 raise DataEnrichmentError('Failed to produce enriched data for ' + self.backend_section)
 
-            logger.info('[%s] enrichment finished for %s', self.backend_section, repo)
+            logger.info('[%s] enrichment finished for %s', self.backend_section, self.anonymize_url(repo))
 
         spent_time = str(datetime.now() - time_start).split('.')[0]
         logger.info('[%s] enrichment phase finished in %s', self.backend_section, spent_time)


### PR DESCRIPTION
This code removes the credentials that appear in the URLs of Git private repos (defined within the
projects.json) in log messages. Furthermore, the method in charge of removing such credentials
have been modified to keep the protocol used (e.g., http and https).