### PR TITLE
[task_identities] add `no-enrollment-periods-validation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ new data sources, thus you need to manually delete the dashboards `Data Status` 
  * **password** (str: ): Password to access the Sortinghat database (**Required**)
  * **reset_on_load** (bool: False): Unmerge and remove affiliations for all identities on load
  * **sleep_for** (int: 3600): Delay between task identities executions (**Required**)
- * **strict_mapping** (bool: True): rigorous check of values in identities matching (i.e, well formed email addresses)
+ * **strict_mapping** (bool: True): rigorous check of values in identities matching (i.e, well formed email addresses, non-overlapping enrollment periods)
  * **unaffiliated_group** (str: Unknown): Name of the organization for unaffiliated identities (**Required**)
  * **user** (str: root): User to access the Sortinghat database (**Required**)
 ### [backend-name:tag] (tag is optional)

--- a/sirmordred/task_identities.py
+++ b/sirmordred/task_identities.py
@@ -252,6 +252,7 @@ class TaskIdentitiesLoad(Task):
                    '-o', json_identities]
             if not cfg['sortinghat']['strict_mapping']:
                 cmd += ['--no-email-validation']
+                cmd += ['--no-enrollment-periods-validation']
             if self.__execute_command(cmd) != 0:
                 logger.error('Can not generate the SH JSON file from '
                              'GrimoireLab yaml file. Do the files exists? '


### PR DESCRIPTION
This code add the command `--no-enrollment-periods-validation`
when the `strict_mapping` is deactivated in the `setup.cfg` file.

Signed-off-by: Quan Zhou <quan@bitergia.com>