### PR TITLE
[aliases] Remove affiliations and all_enriched aliases for github2

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -247,12 +247,6 @@
             ]
           }
         }
-      },
-      {
-        "alias": "affiliations"
-      },
-      {
-        "alias": "all_enriched"
       }
     ]
   },
@@ -265,12 +259,6 @@
     "enrich": [
       {
         "alias": "github2_pull_requests"
-      },
-      {
-        "alias": "affiliations"
-      },
-      {
-        "alias": "all_enriched"
       }
     ]
   },


### PR DESCRIPTION
This code removes the aliases affiliations and all_enriched for github2:issue and github2:pull. This change is needed to avoid overlaps between the github and github2 data (which are similar).