### PR TITLE
[config] Add support for duration analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,19 @@ api-token = xxxxx
 sleep-for-rate = true
 sleep-time = "300" (optional)
 no-archive = true (suggested)
+studies = [enrich_duration_analysis:kanban]
+
+[enrich_duration_analysis:kanban]
+start_event_type = MovedColumnsInProjectEvent
+fltr_attr = board_name
+target_attr = board_column
+fltr_event_types = [MovedColumnsInProjectEvent, AddedToProjectEvent]
+
+[enrich_duration_analysis:label]
+start_event_type = UnlabeledEvent
+target_attr = label
+fltr_attr = label
+fltr_event_types = [LabeledEvent]
 ```
 
 #### github2 [&uarr;](#supported-data-sources-)

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -528,7 +528,8 @@ class Config():
         studies = ("enrich_demography", "enrich_areas_of_code", "enrich_onion", "kafka_kip",
                    "enrich_pull_requests", "enrich_git_branches", "enrich_cocom_analysis",
                    "enrich_colic_analysis", "enrich_geolocation", "enrich_forecast_activity",
-                   "enrich_extra_data", "enrich_feelings", "enrich_backlog_analysis")
+                   "enrich_extra_data", "enrich_feelings", "enrich_backlog_analysis",
+                   "enrich_duration_analysis")
 
         return studies
 


### PR DESCRIPTION
This code adds supports for the duration analysis study. It also includes the documentation to execute it.

Related to https://github.com/chaoss/grimoirelab-elk/pull/893