### PR TITLE
Fix lifecycle file name

### DIFF
--- a/menu.yaml
+++ b/menu.yaml
@@ -14,7 +14,7 @@
   - name: Areas of code
     panel: panels/json/git_areas_of_code.json
   - name: Lifecycle
-    panel: panels/json/lifecyle.json
+    panel: panels/json/lifecycle.json
 - name: Gerrit
   source: gerrit
   icon: default.png


### PR DESCRIPTION
Needed once https://github.com/chaoss/grimoirelab-sigils/pull/457 is merged because the file name is fixed there.

There was a typo in GrimoireLab-Sigils and the name of the file
was misspelled.

Signed-off-by: Alberto Pérez García-Plaza <alpgarcia@bitergia.com>