### PR TITLE
Add new study "demography_contribution"

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,13 +468,17 @@ user = xxxx
 no-archive = true (suggested)
 blacklist-ids = [] (optional)
 max-reviews = 500 (optional)
-studies = [enrich_demography:gerrit, enrich_onion:gerrit] (optional)
+studies = [enrich_demography:gerrit, enrich_onion:gerrit, enrich_demography_contribution:gerrit] (optional)
 
 [enrich_demography:gerrit] (optional)
 
 [enrich_onion:gerrit] (optional)
 in_index = gerrit_enriched
 out_index = gerrit-onion_enriched
+
+[enrich_demography_contribution:gerrit] (optional)
+date_field = grimoire_creation_date
+author_field = author_uuid
 ```
 #### git [&uarr;](#supported-data-sources-)
 Commits from Git

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -19,6 +19,8 @@
 # Authors:
 #       Alvaro del Castillo <acs@bitergia.com>
 #       Luis Cañas-Díaz <lcanas@bitergia.com>
+#       Quan Zhou <quan@bitergia.com>
+#
 
 import configparser
 import logging
@@ -529,7 +531,7 @@ class Config():
                    "enrich_pull_requests", "enrich_git_branches", "enrich_cocom_analysis",
                    "enrich_colic_analysis", "enrich_geolocation", "enrich_forecast_activity",
                    "enrich_extra_data", "enrich_feelings", "enrich_backlog_analysis",
-                   "enrich_duration_analysis")
+                   "enrich_duration_analysis", "enrich_demography_contribution")
 
         return studies
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,7 @@ class TestConfig(unittest.TestCase):
         enrich_onion_github_params = config.conf['enrich_onion:github'].keys()
         enrich_onion_gerrit_params = config.conf['enrich_onion:gerrit'].keys()
         enrich_demography_gerrit_params = config.conf['enrich_demography:gerrit'].keys()
+        enrich_demography_contribution_gerrit_params = config.conf['enrich_demography_contribution:gerrit'].keys()
 
         self.assertIn('general', top_sections)
         self.assertIn('projects', top_sections)
@@ -112,6 +113,11 @@ class TestConfig(unittest.TestCase):
         self.assertIn('sort_on_field', enrich_onion_github_params)
         self.assertIn('no_incremental', enrich_onion_github_params)
         self.assertIn('seconds', enrich_onion_github_params)
+
+        self.assertIn('gerrit', top_sections)
+        self.assertIn('enrich_demography_contribution:gerrit', top_sections)
+        self.assertIn('date_field', enrich_demography_contribution_gerrit_params)
+        self.assertIn('author_field', enrich_demography_contribution_gerrit_params)
 
         self.assertIn('gerrit', top_sections)
         self.assertIn('enrich_demography:gerrit', top_sections)

--- a/tests/test_studies.cfg
+++ b/tests/test_studies.cfg
@@ -130,7 +130,11 @@ no-archive = true
 max-reviews = 100
 raw_index = ???
 enriched_index = ???
-studies = [enrich_demography:gerrit, enrich_onion:gerrit]
+studies = [enrich_demography:gerrit, enrich_onion:gerrit, enrich_demography_contribution:gerrit]
+
+[enrich_demography_contribution:gerrit]
+date_field = ???         # default: grimoire_creation_date
+author_field = ???       # default: author_uuid
 
 [enrich_demography:gerrit]
 date_field = ???         # default: grimoire_creation_date


### PR DESCRIPTION
This new study creates new fields to give us the first and last
date of different contribution types for each author.

Note: once there is a panel based on this study, `sirmordred/task_panels.py` has to be updated including the path to the corresponding JSON file with the index pattern

Signed-off-by: Quan Zhou <quan@bitergia.com>