### PR TITLE
[docs] Update the mariadb docker-compose configuration

### DIFF
--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -31,13 +31,18 @@ Note: For accessing Kibiter and/or creating indexes login is required, the `user
 ```
 services:
     mariadb:
+      restart: on-failure:5
       image: mariadb:10.0
       expose:
         - "3306"
+      ports:
+        - "3306:3306"
       environment:
         - MYSQL_ROOT_PASSWORD=
         - MYSQL_ALLOW_EMPTY_PASSWORD=yes
-
+        - MYSQL_DATABASE=test_sh
+      command: --wait_timeout=2592000 --interactive_timeout=2592000 --max_connections=300
+        
     elasticsearch:
       image: bitergia/elasticsearch:6.8.6-secured
       command: elasticsearch -Enetwork.bind_host=0.0.0.0 -Ehttp.max_content_length=2000mb


### PR DESCRIPTION
Signed-off-by: Sourabh Saraswat <saraswatsourabh5@gmail.com>

expose =>as it activates container to listen for a specific port only from the world inside of docker AND not accessible from world outside of the docker . So that's why this create an issue with connection to database when we run micro-mordred .
as per reference [https://docs.docker.com/engine/reference/builder/#expose](https://docs.docker.com/engine/reference/builder/#expose)

So to overcome this we can use :
ports =>  as it activates the container to listen for specified port(s) from the world outside of the docker AND also accessible world inside docker.

and there is one more issue while setting up grimoire lab from docker-compose (with SearchGuard) that it have no database with name of "test_sh" which creates an error "no database of name 'test_sh' " while running micro-mordred .
So for this , i added a database of this name in mysql by default .