### PR TITLE
[micro-mordred] Improve error messages in micro.py

### DIFF
--- a/utils/micro.py
+++ b/utils/micro.py
@@ -221,6 +221,10 @@ def get_params():
         print("No tasks enabled")
         sys.exit(1)
 
+    if args.cfg_path is None:
+        print("Config file path not provided")
+        sys.exit(1)
+
     return args
 
 


### PR DESCRIPTION
Improve error message when config file is not provided while executing micro.py.

Signed-off-by: Rohan Reddy <rohan.ch.reddy@gmail.com>