### PR TITLE
Update gitlab example in utils/projects.json

### DIFF
--- a/utils/projects.json
+++ b/utils/projects.json
@@ -22,10 +22,10 @@
            "https://build.opnfv.org/ci"
         ],
         "gitlab:issue": [
-            "https://gitlab.com/gitlab-org/gitlab-ce"
+            "https://gitlab.com/gitlab-org/gitlab-development-kit"
         ],
         "gitlab:merge": [
-            "https://gitlab.com/gitlab-org/gitlab-ce"
+            "https://gitlab.com/gitlab-org/gitlab-development-kit"
         ]
     }
 }


### PR DESCRIPTION
Currently, projects.json contains an entry for gitlab-org/gitlab-ce as an example for both gitlab:issue and gitlab:merge.  However, attempting to run this with sirmordred (I tested with micromordred), this causes a 404 error, since this project has since since moved to gitlab-org/gitlab-foss.

This commit simply updates the examples in projects.json to the post-migration repo url.