### PR TITLE
[mordred] Add flag/arg to filter which repos run

### DIFF
--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -40,10 +40,11 @@ logger = logging.getLogger(__name__)
 class TaskRawDataCollection(Task):
     """ Basic class shared by all collection tasks """
 
-    def __init__(self, config, backend_section=None):
+    def __init__(self, config, backend_section=None, allowed_repos=None):
         super().__init__(config)
 
         self.backend_section = backend_section
+        self.allowed_repos = set(allowed_repos) if allowed_repos else None
         # This will be options in next iteration
         self.clean = False
 
@@ -89,6 +90,9 @@ class TaskRawDataCollection(Task):
 
         if not repos:
             logger.warning("No collect repositories for %s", self.backend_section)
+        elif self.allowed_repos is not None:
+            # Filter repos to only those specified
+            repos = sorted(list(set(repos) & self.allowed_repos))
 
         for repo in repos:
             repo, repo_labels = self._extract_repo_labels(self.backend_section, repo)

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -54,9 +54,10 @@ logger = logging.getLogger(__name__)
 class TaskEnrich(Task):
     """ Basic class shared by all enriching tasks """
 
-    def __init__(self, config, backend_section=None):
+    def __init__(self, config, backend_section=None, allowed_repos=None):
         super().__init__(config)
         self.backend_section = backend_section
+        self.allowed_repos = set(allowed_repos) if allowed_repos else None
         # This will be options in next iteration
         self.clean = False
         # check whether the aliases has beed already created
@@ -140,6 +141,9 @@ class TaskEnrich(Task):
 
         if not repos:
             logger.warning("No enrich repositories for %s", self.backend_section)
+        elif self.allowed_repos is not None:
+            # Filter repos to only those specified
+            repos = sorted(list(set(repos) & self.allowed_repos))
 
         # Get the metadata__timestamp value of the last item inserted in the enriched index before
         # looping over the repos which data is stored in the same index. This is needed to make sure


### PR DESCRIPTION
This PR adds an optional argument/flag to the collect/enrich tasks and micro.py that can be specified with a list of repositories.  If set, only repositories in the provided list will be processed during the collect/enrich phase, enabling much quicker run times for large projects.

By allowing users finer control over what parts of a task are executed, users can easily manage much larger `projects.json` files without needing to wait for an entire backend to be collected/enriched every time they want to perform a collection/enrichment.

This introduces only one breaking change in the micro.py file, in the form of a new positional argument.  This was done in order to maintain the style of arguments accepted by that function, and because it is much less likely that micro.py will be used as a library.  All other methods offer the new behavior as an optional kwarg which maintains the current behavior if not specified.

Closes #511 