### PR TITLE
[config]  Support inheritance in configuration

### DIFF
--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -527,9 +527,9 @@ class TaskPanelsMenu(Task):
         active_ds = []
         for entry in self.panels_menu:
             ds = entry['source']
-            if ds in self.conf.keys() or ds in [COMMUNITY_SOURCE, KAFKA_SOURCE, GITLAB_ISSUES, GITLAB_MERGES,
-                                                MATTERMOST, GITHUB_COMMENTS, GITHUB_REPOS, GITHUB_EVENTS,
-                                                COCOM_SOURCE, COLIC_SOURCE]:
+            if ds in self.conf or ds in [COMMUNITY_SOURCE, KAFKA_SOURCE, GITLAB_ISSUES, GITLAB_MERGES,
+                                         MATTERMOST, GITHUB_COMMENTS, GITHUB_REPOS, GITHUB_EVENTS,
+                                         COCOM_SOURCE, COLIC_SOURCE]:
                 active_ds.append(ds)
         logger.debug("Active data sources for menu: %s", active_ds)
 

--- a/tests/test_task_enrich.py
+++ b/tests/test_task_enrich.py
@@ -150,32 +150,32 @@ class TestTaskEnrich(unittest.TestCase):
         task = TaskEnrich(config, backend_section=backend_section)
 
         # Configure no studies
-        cfg['git']['studies'] = None
+        cfg.set_param('git', 'studies', None)
         self.assertEqual(task.execute(), None)
 
         # Configure no studies
-        cfg['git']['studies'] = []
+        cfg.set_param('git', 'studies', [])
         self.assertEqual(task.execute(), None)
 
         # Configure a wrong study
-        cfg['git']['studies'] = ['bad_study']
+        cfg.set_param('git', 'studies', ['bad_study'])
         with self.assertRaises(DataEnrichmentError):
             self.assertEqual(task.execute(), None)
 
         # Configure several studies
-        cfg['git']['studies'] = ['enrich_onion']
+        cfg.set_param('git', 'studies', ['enrich_onion'])
         self.assertEqual(task.execute(), None)
 
         # Configure several studies
-        cfg['git']['studies'] = ['enrich_demography:1', 'enrich_areas_of_code']
+        cfg.set_param('git', 'studies', ['enrich_demography:1', 'enrich_areas_of_code'])
         self.assertEqual(task.execute(), None)
 
         # Configure kafka kip study
-        cfg['mbox']['studies'] = ['kafka_kip']
+        cfg.set_param('mbox', 'studies', ['kafka_kip'])
         self.assertEqual(task.execute(), None)
 
         # Configure several studies, one wrong
-        cfg['git']['studies'] = ['enrich_demography:1', "enrich_areas_of_code1"]
+        cfg.set_param('git', 'studies', ['enrich_demography:1', "enrich_areas_of_code1"])
         with self.assertRaises(DataEnrichmentError):
             self.assertEqual(task.execute(), None)
 


### PR DESCRIPTION
Adds in support for parameter-based inheritance in configuration.

In short, `[backend:param1:param2]` will implicitly inherit any configuration options from `[backend:param2]`, '[backend:param1]`, and `[backend]`, and each will automatically override options from it's predecessor with its own, if provided.

This allows configuration files to become much smaller by reducing duplicate config options.  For example, the following `[gitlab]` config...

```ini
[gitlab:flagship:issue]
api-token = aabbccdd1234
raw_index = gitlab_issues_raw
enriched_index = gitlab_issues_enriched
no-archive = true
sleep-for-rate = true

[gitlab:flagship:merge]
api-token = aabbccdd1234
raw_index = gitlab_merges_raw
enriched_index = gitlab_merges_enriched
no-archive = true
category = merge_request
sleep-for-rate = true

[gitlab:ieee:issue]
api-token = ppqqrrss9876
raw_index = gitlab_issues_raw
enriched_index = gitlab_issues_enriched
no-archive = true
sleep-for-rate = true
enterprise-url = https://opensource.ieee.org

[gitlab:ieee:merge]
api-token = ppqqrrss9876
raw_index = gitlab_merges_raw
enriched_index = gitlab_merges_enriched
no-archive = true
category = merge_request
sleep-for-rate = true
enterprise-url = https://opensource.ieee.org
```

...can be reduced to:

```ini
[gitlab]
api-token = aabbccdd1234
raw_index = gitlab_issues_raw
enriched_index = gitlab_issues_enriched
no-archive = true
sleep-for-rate = true

[gitlab:merge]
category = merge_request
raw_index = gitlab_merges_raw
enriched_index = gitlab_merges_enriched

[gitlab:ieee]
api-token = ppqqrrss9876
enterprise-url = https://opensource.ieee.org
```

and look exactly the same to the code.  This is because a section such as `[gitlab:ieee:merge]` would inherit the category and index from `[gitlab:merge]`, the api token and enterprise url from `[gitlab:ieee]`, and the no-archive and sleep-for-rate settings from `[gitlab]`

Additionally, any configurations written before this change will still behave exactly the same.  This commit introduces ZERO breaking changes, and existing `projects.json` files and `setup.cfg` files will continue working EXACTLY the same way.  The only thing this commit changes is that it is now possible to write these inheriting `setup.cfg` files.  This does not require nor enable any changes to `projects.json` at all.  There is no new behavior for `projects.json` nor any changes regarding it.

One change has been made to the tests that I believe is justifiable.  Namely, a previous use of modifying the config using `Config.get_conf()` has been replaced with `Config.set_param()`.  Given that `Config.get_conf()` had a TODO indicating that it was going to use a deep copy to specifically prevent this usage, I'm going to assume that this was not a supported usecase in the firstplace.

Additionally, tests have been added to guarantee the functionality as described above.

Another important note is that the `Config` object now behaves directly as a config dict.  This enables the dynamic generation of parameterized config sections.

As a note, I've typed much of my code here as a personal preference, since I just find it easier to code with typechecking, but if it is preferred, I don't mind taking it back out

This was added following the discussion that took place in #515 as well as a discussion that took place between me (Emi) and @sduenas on the CHAOSS slack. (Closes #515)