### PR TITLE
[task_manager] Add `update_hour` in the general section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ new data sources, thus you need to manually delete the dashboards `Data Status` 
  * **menu_file** (str: ./menu.yaml): YAML file to define the menus to be shown in Kibiter
  * **global_data_sources** (list: bugzilla, bugzillarest, confluence, discourse, gerrit, jenkins, jira): List of data sources collected globally, they are declared in the section 'unknown' of the projects.json
  * **retention_time** (int: None): the maximum number of minutes wrt the current date to retain the data
+ * **update_hour** (int: None): The hour of the day the tasks will run ignoring `min_update_delay` (collect, enrich ...)
 ### [panels]
 
  * **community** (bool: True): Include community section in dashboard

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -104,6 +104,12 @@ class Config():
                     "type": int,
                     "description": "Short delay between tasks (collect, enrich ...)"
                 },
+                "update_hour": {
+                    "optional": True,
+                    "default": None,
+                    "type": int,
+                    "description": "Start the next execution (collect, enrich ...)"
+                },
                 "update": {
                     "optional": False,
                     "default": False,

--- a/tests/test.cfg
+++ b/tests/test.cfg
@@ -17,6 +17,7 @@
 short_name = Grimoire
 update = false
 min_update_delay = 10
+update_hour = 9
 debug = true
 # /var/log/sigmordred/
 logs_dir = logs


### PR DESCRIPTION
The `update_hour` parameter allows running tasks
(collect, enrich ...) at a specific hour of the day ignoring
`min_update_delay`. By default is `None`.

Test added accordingly.
Readme added accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>