### PR TITLE
[utils] Update setup.cfg to reflect new file structure 

### DIFF
--- a/sirmordred/utils/setup.cfg
+++ b/sirmordred/utils/setup.cfg
@@ -24,8 +24,8 @@ logs_dir = logs
 bulk_size = 100
 # Number of items to get from Elasticsearch when scrolling
 scroll_size = 100
-menu_file = ../menu.yaml
-aliases_file = ../aliases.json
+menu_file = ../../menu.yaml
+aliases_file = ../../aliases.json
 
 [projects]
 projects_file = ./projects.json


### PR DESCRIPTION
`menu_file` and `aliases_file` have moved in the directory structure since the last update of `setup.cfg`, and the updated paths for them in this change will fix the file not found errors upon running micro-mordred. This is a solution that does not move the positions of any files.
Fixes #538.

Signed-off-by: Mabel <70232089+mabelbot@users.noreply.github.com>