### PR TITLE
Update base docker image to Debian "bullseye"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-# Copyright (C) 2016-2017 Bitergia
+# Copyright (C) 2016-2022 Bitergia
 # GPLv3 License
 
-FROM debian:buster-slim
-MAINTAINER Jesus M. Gonzalez-Barahona <jgb@bitergia.com>, Alvaro del Castillo <acs@bitergia.com>
+FROM debian:bullseye-slim
+LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEPLOY_USER bitergia


### PR DESCRIPTION
The base image we were using is old and deprecated. This change updates the image to the latest Debian
stable image, codenamed "bullseye".
