### PR TITLE
Relocate studies aliases

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -159,12 +159,6 @@
       },
       {
         "alias": "all_enriched"
-      },
-      {
-        "alias": "all_onion"
-      },
-      {
-        "alias": "demographics"
       }
     ]
   },
@@ -189,15 +183,6 @@
       },
       {
         "alias": "all_enriched"
-      },
-      {
-        "alias": "all_onion"
-      },
-      {
-        "alias": "demographics"
-      },
-      {
-        "alias": "git_areas_of_code"
       }
     ]
   },
@@ -314,12 +299,6 @@
             ]
           }
         }
-      },
-      {
-        "alias": "all_onion"
-      },
-      {
-        "alias": "demographics"
       }
     ]
   },
@@ -341,12 +320,6 @@
       },
       {
         "alias": "all_enriched_tickets"
-      },
-      {
-        "alias": "all_onion"
-      },
-      {
-        "alias": "demographics"
       }
     ]
   },
@@ -365,12 +338,6 @@
       },
       {
         "alias": "all_enriched"
-      },
-      {
-        "alias": "all_onion"
-      },
-      {
-        "alias": "demographics"
       }
     ]
   },
@@ -515,9 +482,6 @@
       },
       {
         "alias": "all_enriched"
-      },
-      {
-        "alias": "demographics"
       }
     ]
   },
@@ -884,9 +848,19 @@
       },
       {
         "alias": "all_enriched"
+      }
+    ]
+  },
+  "studies_aliases": {
+    "enrich": [
+      {
+        "alias": "all_onion"
       },
       {
         "alias": "demographics"
+      },
+      {
+        "alias": "git_areas_of_code"
       }
     ]
   }

--- a/releases/unreleased/studies-aliases-relocated.yml
+++ b/releases/unreleased/studies-aliases-relocated.yml
@@ -1,0 +1,7 @@
+---
+title: Studies aliases relocated
+category: fixed
+author: Angel Jara <ajara@bitergia.com>
+issue: null
+notes: >
+    Relocate studies aliases so they are not created automatically by Mordred.


### PR DESCRIPTION
Studies aliases shouldn't be made to point to data source indices
directly. Otherwise they could end pointing to indices that don't have
studies data. And the studies visualizations would show wrong data.
Instead, since they are studies, Mordred will automatically create
these aliases pointing to the correct indices.

However, we'd like that these aliases are listed in a fake data source,
so we can list all possible enriched aliases for other purposes.

Signed-off-by: Angel Jara <ajara@bitergia.com>