### PR TITLE
Set versions of Python to 3.8 and GrimoireLab to 0.3.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) 2016-2022 Bitergia
 # GPLv3 License
 
-FROM debian:bullseye-slim
+FROM python:3.8-slim-bullseye
 LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ENV DEPLOY_USER bitergia
 ENV DEPLOY_USER_DIR /home/${DEPLOY_USER}
 ENV CONF_DIR ${DEPLOY_USER_DIR}/conf
 ENV SCRIPTS_DIR ${DEPLOY_USER_DIR}/scripts
-ENV GRIMOIRELAB_RELEASE "0.2.69"
+ENV GRIMOIRELAB_RELEASE "0.3.0"
 
 # Initial user
 RUN useradd ${DEPLOY_USER} --create-home --shell /bin/bash


### PR DESCRIPTION
This PR sets the versions of the image to Python 3.8 and GrimoireLab 0.3.0.