### PR TITLE
[task_enrich] Fix git pair-programming activation

### DIFF
--- a/releases/unreleased/[git]-pair-programming-activation-fixed.yml
+++ b/releases/unreleased/[git]-pair-programming-activation-fixed.yml
@@ -1,0 +1,8 @@
+---
+title: '[git] pair-programming activation fixed'
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Git pair-programming can be activated if the data source
+    contains a tag like `[git:pair]`

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -129,8 +129,9 @@ class TaskEnrich(Task):
         github_token = None
         pair_programming = False
         node_regex = None
-        if 'git' in cfg and 'pair-programming' in cfg['git']:
-            pair_programming = cfg['git']['pair-programming']
+
+        if self.backend_section in cfg and 'pair-programming' in cfg[self.backend_section]:
+            pair_programming = cfg[self.backend_section]['pair-programming']
         if 'jenkins' in cfg and 'node_regex' in cfg['jenkins']:
             node_regex = cfg['jenkins']['node_regex']
         only_studies = False


### PR DESCRIPTION
This fixes when the name of the data source to enable
pair-programming contains a tag like `[git:pair]`.

The current behavior only works if the data source is `[git]`.

Signed-off-by: Quan Zhou <quan@bitergia.com>