### PR TITLE
[task_enrich] Allows to customize the name of the study aliases

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -854,13 +854,20 @@
   "studies_aliases": {
     "enrich": [
       {
-        "alias": "all_onion"
+        "alias": "all_onion",
+        "name": "enrich_onion"
       },
       {
-        "alias": "demographics"
+        "alias": "demographics",
+        "name": "enrich_demography"
       },
       {
-        "alias": "git_areas_of_code"
+        "alias": "demographics_contribution",
+        "name": "enrich_demography_contribution"
+      },
+      {
+        "alias": "git_areas_of_code",
+        "name": "enrich_areas_of_code"
       }
     ]
   }

--- a/releases/unreleased/[task_enrich]-the-alias-configuration-file-now-includes-the-study-names.yml
+++ b/releases/unreleased/[task_enrich]-the-alias-configuration-file-now-includes-the-study-names.yml
@@ -1,0 +1,23 @@
+---
+title: 'Configurable study names and aliases'
+category: added
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Study aliases and names can be set in the configuration file using the
+    keyword `studies_aliases`. The following snippet shows an example of
+    configuration.
+
+    i.e. In this `aliases.json` file the name of the study is
+    `enrich_onion` and the name of the alias is `all_onion`
+    ```
+    "studies_aliases": {
+        "enrich": [
+          {
+            "alias": "all_onion",
+            "name": "enrich_onion"
+          },
+          ...
+        ]
+    }
+    ```

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -347,6 +347,10 @@ class TaskEnrich(Task):
         logger.info("%s Executing studies %s" % (log_prefix, [study for study in studies]))
 
         studies_args = self.__load_studies()
+        study_aliases = self.select_aliases(cfg, "studies_aliases")
+        for study_arg in studies_args:
+            alias = [study_alias['alias'] for study_alias in study_aliases if study_arg['type'] == study_alias['name']]
+            study_arg['params']['alias'] = alias[0]
 
         do_studies(ocean_backend, enrich_backend, studies_args, retention_time=retention_time)
         # Return studies to its original value

--- a/tests/aliases.json
+++ b/tests/aliases.json
@@ -154,5 +154,25 @@
   "twitter": {
       "raw": ["twitter-raw"],
       "enrich": ["twitter", "affiliations"]
+  },
+  "studies_aliases": {
+    "enrich": [
+      {
+        "alias": "all_onion",
+        "name": "enrich_onion"
+      },
+      {
+        "alias": "demographics",
+        "name": "enrich_demography"
+      },
+      {
+        "alias": "demographics_contribution",
+        "name": "enrich_demography_contribution"
+      },
+      {
+        "alias": "git_areas_of_code",
+        "name": "enrich_areas_of_code"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This code allows you to customize the name of the study aliases
for the indexes. These names come from the aliases.json file now,
so the hardcoded names were removed.

i.e. In this aliases.json file the name of the study is
`enrich_onion` and the name of the alias is `all_onion`
```
"studies_aliases": {
    "enrich": [
      {
        "alias": "all_onion",
        "name": "enrich_onion"
      },
      ...
    ]
}
```

Test updated accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>