### PR TITLE
[poetry] Allow Grimoirelab prereleases in dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -956,7 +956,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "fc1056962131d97d08de6ed570844663ca653b41c69c53ef6a5b2f315583ab99"
+content-hash = "081ef102504f8eb4a5e79414c8cfc41c64748ce202f89f1b23c681e75dfb65ca"
 
 [metadata.files]
 astroid = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,11 @@ colorlog = "4.1.0"
 elasticsearch = "6.3.1"
 elasticsearch-dsl = "6.3.1"
 file-read-backwards = "2.0.0"
-grimoirelab-toolkit = ">=0.3"
-sortinghat = ">=0.7.20"
-kidash = ">=0.5"
-grimoire-elk = ">=0.102"
-grimoirelab-panels = ">=0.1"
+grimoirelab-toolkit = { version = ">=0.3", allow-prereleases = true}
+sortinghat = { version = ">=0.7.20", allow-prereleases = true}
+kidash = { version = ">=0.5", allow-prereleases = true}
+grimoire-elk = { version = ">=0.102", allow-prereleases = true}
+grimoirelab-panels = { version = ">=0.1", allow-prereleases = true}
 
 [tool.poetry.dev-dependencies]
 httpretty = "^1.1.4"


### PR DESCRIPTION
This commit updates the dependencies for this package and includes the `allow-prerelease` option for all grimoirelab dependencies.
