### PR TITLE
[task_enrich] Fix study selection

### DIFF
--- a/releases/unreleased/study-selection-fixed.yml
+++ b/releases/unreleased/study-selection-fixed.yml
@@ -1,0 +1,8 @@
+---
+title: Study selection fixed
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    This fix solves the problem of executing the studies with
+    no associated aliases.

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -350,7 +350,8 @@ class TaskEnrich(Task):
         study_aliases = self.select_aliases(cfg, "studies_aliases")
         for study_arg in studies_args:
             alias = [study_alias['alias'] for study_alias in study_aliases if study_arg['type'] == study_alias['name']]
-            study_arg['params']['alias'] = alias[0]
+            if alias:
+                study_arg['params']['alias'] = alias[0]
 
         do_studies(ocean_backend, enrich_backend, studies_args, retention_time=retention_time)
         # Return studies to its original value


### PR DESCRIPTION
This code fixes the case when the study does not need an
associated alias.

Before this change the studies without needing an alias were
failing.

Signed-off-by: Quan Zhou <quan@bitergia.com>