### PR TITLE
[docker/stage] Remove temporary perceval files

### DIFF
--- a/docker/stage
+++ b/docker/stage
@@ -5,5 +5,6 @@ CONF_DIR="$HOME_DIR/conf"
 CONF_LIST="${MORDRED_CONF_FILES:-$CONF_DIR/setup.cfg}"
 
 rm -f /tmp/.mordred_healthcheck
+rm -f /tmp/perceval_*
 
 sirmordred -c ${CONF_LIST}


### PR DESCRIPTION
This code removes temporary `perceval` files after a restart to avoid filling up the disk.

Signed-off-by: Quan Zhou <quan@bitergia.com>