### PR TITLE
Add all logs to console handler

### DIFF
--- a/releases/unreleased/sirmordred-logs-available-on-console.yml
+++ b/releases/unreleased/sirmordred-logs-available-on-console.yml
@@ -1,0 +1,10 @@
+---
+title: SirMordred logs available on console
+category: added
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    All SirMordred logs are now available on the console output.
+
+    The `logs_dir` parameter in the `general` section is optional
+    and it is only needed if you also want the logs in a file.

--- a/sirmordred/bin/sirmordred.py
+++ b/sirmordred/bin/sirmordred.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2019 Bitergia
+# Copyright (C) 2015-2023 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -60,7 +60,7 @@ def main():
     try:
         config = Config(args.config_files[0], args.config_files[1:])
         config_dict = config.get_conf()
-        logs_dir = config_dict['general']['logs_dir']
+        logs_dir = config_dict['general'].get('logs_dir', None)
         debug_mode = config_dict['general']['debug']
         logger = setup_logs(logs_dir, debug_mode)
     except RuntimeError as error:
@@ -87,20 +87,24 @@ def setup_logs(logs_dir, debug_mode):
 
     logger = logging.getLogger()
     logger.setLevel(logging_mode)
-    # create file handler which logs even debug messages
 
-    fh_filepath = os.path.join(logs_dir, 'all.log')
-    fh = logging.FileHandler(fh_filepath)
-    fh.setLevel(logging_mode)
-    # create console handler with a higher log level
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.ERROR)
     # create formatter and add it to the handlers
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    fh.setFormatter(formatter)
+
+    # create file handler
+    if logs_dir:
+        fh_filepath = os.path.join(logs_dir, 'all.log')
+        fh = logging.FileHandler(fh_filepath)
+        fh.setLevel(logging_mode)
+        # Set format
+        fh.setFormatter(formatter)
+        # add the handlers to the logger
+        logger.addHandler(fh)
+
+    # create console handler
+    ch = logging.StreamHandler()
+    ch.setLevel(logging_mode)
     ch.setFormatter(formatter)
-    # add the handlers to the logger
-    logger.addHandler(fh)
     logger.addHandler(ch)
 
     # this is needed because the perceval log messages are similar to ELK/mordred ones

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -129,8 +129,8 @@ class Config():
                     "description": "Debug mode (logging mainly)"
                 },
                 "logs_dir": {
-                    "optional": False,
-                    "default": "logs",
+                    "optional": True,
+                    "default": None,
                     "type": str,
                     "description": "Directory with the logs of sirmordred"
                 },


### PR DESCRIPTION
This commit adds all SirMordred logs to console handler. Only when the `logs_dir` parameter in the `general` section is set, it will also write the logs in that file.

Now the `logs_dir` parameter is optional.

Signed-off-by: Quan Zhou <quan@bitergia.com>