### PR TITLE
[sortinghat] Include `verify_ssl` option for SortingHat

### DIFF
--- a/releases/unreleased/sortinghat-option-to-verify-ssl.yml
+++ b/releases/unreleased/sortinghat-option-to-verify-ssl.yml
@@ -1,0 +1,8 @@
+---
+title: SortingHat option to verify SSL
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: |
+  Include `verify_ssl` option to SortingHat configuration to verify
+  the connection with the server. By default it is `True`.

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -482,6 +482,12 @@ class Config():
                     "default": False,
                     "type": bool,
                     "description": "GraphQL server use SSL/TSL connection"
+                },
+                "verify_ssl": {
+                    "optional": True,
+                    "default": True,
+                    "type": bool,
+                    "description": "Verify SSL connection to the server"
                 }
             }
         }

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -55,11 +55,13 @@ class Task():
         self.db_path = sortinghat.get('path', None) if sortinghat else None
         self.db_port = sortinghat.get('port', None) if sortinghat else None
         self.db_ssl = sortinghat.get('ssl', False) if sortinghat else False
+        self.db_verify_ssl = sortinghat.get('verify_ssl', True) if sortinghat else True
         self.db_unaffiliate_group = sortinghat['unaffiliated_group'] if sortinghat else None
         if sortinghat:
             self.client = SortingHatClient(host=self.db_host, port=self.db_port,
                                            path=self.db_path, ssl=self.db_ssl,
-                                           user=self.db_user, password=self.db_password)
+                                           user=self.db_user, password=self.db_password,
+                                           verify_ssl=self.db_verify_ssl)
             self.client.connect()
         else:
             self.client = None

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -194,6 +194,7 @@ class TaskEnrich(Task):
                                self.db_port,
                                self.db_path,
                                self.db_ssl,
+                               self.db_verify_ssl,
                                None,  # args.refresh_projects,
                                None,  # args.refresh_identities,
                                author_id=None,


### PR DESCRIPTION
This PR includes a new method in the enrichment process to verify the connection to the SortingHat database when using SSL. By default, this option is set to True.

Depends on https://github.com/chaoss/grimoirelab-elk/pull/1101 and https://github.com/chaoss/grimoirelab-sortinghat/pull/737