### PR TITLE
[ci] Update deprecated ubuntu-18.04 of GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
   tests:
     needs: [build]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     services:
       mysql:
         image: mysql:5.7


### PR DESCRIPTION
This PR updates the version of the release GitHub action to use ubuntu-latest instead of ubuntu-18.04 wich is deprecated.