### PR TITLE
[cfg] Include tenant in SortingHat config

### DIFF
--- a/releases/unreleased/optional-configuration-for-sortinghat.yml
+++ b/releases/unreleased/optional-configuration-for-sortinghat.yml
@@ -1,0 +1,8 @@
+---
+title: Optional configuration for SortingHat
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Include an optional configuration for SortingHat to define the name
+  of the tenant when multi-tenancy is enabled.

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -488,6 +488,12 @@ class Config():
                     "default": True,
                     "type": bool,
                     "description": "Verify SSL connection to the server"
+                },
+                "tenant": {
+                    "optional": True,
+                    "default": None,
+                    "type": str,
+                    "description": "Tenant name when multi-tenancy is enabled"
                 }
             }
         }

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -56,12 +56,14 @@ class Task():
         self.db_port = sortinghat.get('port', None) if sortinghat else None
         self.db_ssl = sortinghat.get('ssl', False) if sortinghat else False
         self.db_verify_ssl = sortinghat.get('verify_ssl', True) if sortinghat else True
+        self.db_tenant = sortinghat.get('tenant', True) if sortinghat else None
         self.db_unaffiliate_group = sortinghat['unaffiliated_group'] if sortinghat else None
         if sortinghat:
             self.client = SortingHatClient(host=self.db_host, port=self.db_port,
                                            path=self.db_path, ssl=self.db_ssl,
                                            user=self.db_user, password=self.db_password,
-                                           verify_ssl=self.db_verify_ssl)
+                                           verify_ssl=self.db_verify_ssl,
+                                           tenant=self.db_tenant)
             self.client.connect()
         else:
             self.client = None

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -195,6 +195,7 @@ class TaskEnrich(Task):
                                self.db_path,
                                self.db_ssl,
                                self.db_verify_ssl,
+                               self.db_tenant,
                                None,  # args.refresh_projects,
                                None,  # args.refresh_identities,
                                author_id=None,


### PR DESCRIPTION
This PR includes the optional parameter `tenant` in the SortingHat configuration to define the tenant to use when multi-tenancy is enabled.

Depends on https://github.com/chaoss/grimoirelab-sortinghat/pull/767 and https://github.com/chaoss/grimoirelab-elk/pull/1106