### PR TITLE
Fix race condition on initial tasks

### DIFF
--- a/releases/unreleased/race-condition-initializing-sirmordred.yml
+++ b/releases/unreleased/race-condition-initializing-sirmordred.yml
@@ -1,0 +1,12 @@
+---
+title: Race condition initializing SirMordred
+category: fixed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  There was a race condition when SirMordred initializes.
+  The thread that read the list of projects didn't have
+  time to even start before the manager finalizes it,
+  so data backends didn't have any have any input to work
+  with. This bug was originally reported by ncsibra-lab49 on
+  [grimoirelab#585](https://github.com/chaoss/grimoirelab/issues/585).

--- a/sirmordred/task_manager.py
+++ b/sirmordred/task_manager.py
@@ -88,11 +88,10 @@ class TasksManager(threading.Thread):
             logger.debug('[%s] no tasks', self.backend_section)
 
         logger.debug('[%s] Tasks will be executed in this order: %s', self.backend_section, self.tasks)
-        while not self.stopper.is_set():
-            # we give 1 extra second to the stopper, so this loop does
-            # not finish before it is set.
-            time.sleep(1)
 
+        stop_task = False
+
+        while not stop_task:
             for task in self.tasks:
                 logger.debug('[%s] Tasks started: %s', self.backend_section, task)
                 try:
@@ -107,6 +106,8 @@ class TasksManager(threading.Thread):
             if timer > 0 and self.config.get_conf()['general']['update']:
                 logger.info("[%s] sleeping for %s seconds ", self.backend_section, timer)
                 time.sleep(timer)
+
+            stop_task = self.stopper.is_set()
 
         logger.debug('[%s] Task is exiting', self.backend_section)
 


### PR DESCRIPTION
When mordred starts, it loads the dashboards to Kibana and next, it reads the list of projects to analyze. Due to a race condition, the thread that reads the list of projects could not even start, so data backends won't have any input to work with.

This commit fixes the problem adding isolated code that will run the initial tasks. Once these tasks are finished, the main loop will start the task manager.

Fixes chaoss/grimoirelab#585