### PR TITLE
[ci] Install dev packages using Poetry instead of peodd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+
       - name: Configure sysctl limits
         run: |
           sudo swapoff -a
@@ -69,9 +74,7 @@ jobs:
 
       - name: Install dev dependencies
         run: |
-          pip install peodd
-          peodd -o requirements-dev.txt
-          pip install -r requirements-dev.txt
+          poetry install --only dev --no-root
 
       - name: Verify MySQL connection
         run: |
@@ -88,8 +91,6 @@ jobs:
 
       - name: Run Sortinghat Server
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
           git clone --single-branch https://github.com/chaoss/grimoirelab-sortinghat /tmp/sortinghat
           cp tests/sortinghat_settings.py /tmp/sortinghat/config/settings/sortinghat_settings.py
           cd /tmp/sortinghat
@@ -107,8 +108,8 @@ jobs:
       - name: Test package
         run: |
           PACKAGE=`(cd dist && ls *whl)` && echo $PACKAGE
-          pip install --pre ./dist/$PACKAGE
-          cd tests && python run_tests.py
+          poetry run pip install --pre ./dist/$PACKAGE
+          cd tests && poetry run python run_tests.py
 
   release:
     needs: [tests]


### PR DESCRIPTION
Poetry supports installing packages from a specific group since version `1.2`. Replace the use of `peodd` with Poetry in the installation of the test packages.