### PR TITLE
[task] Create a new task that autorefreshes identities periodically

### DIFF
--- a/releases/unreleased/refresh-identities-in-a-shorter-period.yml
+++ b/releases/unreleased/refresh-identities-in-a-shorter-period.yml
@@ -1,0 +1,8 @@
+---
+title: Refresh identities in a shorter period
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  This update significantly reduces the time required for identity
+  refresh operations on large projects.

--- a/sirmordred/sirmordred.py
+++ b/sirmordred/sirmordred.py
@@ -43,6 +43,7 @@ from grimoire_elk.enriched.utils import grimoire_con
 from sirmordred.config import Config
 from sirmordred.error import DataCollectionError
 from sirmordred.error import DataEnrichmentError
+from sirmordred.task_autorefresh import TaskAutorefresh
 from sirmordred.task_collection import TaskRawDataCollection
 from sirmordred.task_enrich import TaskEnrich
 from sirmordred.task_identities import TaskIdentitiesMerge
@@ -297,14 +298,10 @@ class SirMordred:
         if self.conf['phases']['collection']:
             all_tasks_cls.append(TaskRawDataCollection)
         if self.conf['phases']['identities']:
-            # load identities and orgs periodically for updates
-            # all_tasks_cls.append(TaskIdentitiesLoad) Not supported on the new sortinghat graphQL
             all_tasks_cls.append(TaskIdentitiesMerge)
-            # This is done in enrichement before doing the enrich
-            # if self.conf['phases']['collection']:
-            #     all_tasks_cls.append(TaskIdentitiesCollection)
         if self.conf['phases']['enrichment']:
             all_tasks_cls.append(TaskEnrich)
+            all_tasks_cls.append(TaskAutorefresh)
 
         # this is the main loop, where the execution should spend
         # most of its time

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -187,10 +187,10 @@ class Task():
         if 'projects_file' in self.conf['projects']:
             json_projects_map = self.conf['projects']['projects_file']
 
-        enrich_backend = connector[2](self.db_sh, json_projects_map,
-                                      self.db_user, self.db_password, self.db_host,
-                                      self.db_path, self.db_port, self.db_ssl, self.db_verify_ssl,
-                                      self.db_tenant)
+        enrich_backend = connector[2](db_sortinghat=self.db_sh, json_projects_map=json_projects_map,
+                                      db_user=self.db_user, db_password=self.db_password, db_host=self.db_host,
+                                      db_port=self.db_port, db_path=self.db_path, db_ssl=self.db_ssl,
+                                      db_verify_ssl=self.db_verify_ssl, db_tenant=self.db_tenant)
         elastic_enrich = get_elastic(self.conf['es_enrichment']['url'],
                                      self.conf[self.backend_section]['enriched_index'],
                                      clean, enrich_backend)

--- a/sirmordred/task_autorefresh.py
+++ b/sirmordred/task_autorefresh.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Jose Javier Merchante <jjmerchante@bitergia.com>
+#
+
+import logging
+import ssl
+
+from datetime import datetime
+
+from elasticsearch import Elasticsearch
+from elasticsearch.connection import create_ssl_context
+
+from grimoire_elk.elk import refresh_identities
+from grimoire_elk.enriched.git import GitEnrich
+from grimoire_elk.utils import get_elastic, get_connector_from_name
+from grimoire_elk.enriched.sortinghat_gelk import SortingHat
+
+from sirmordred.config import Config
+from sirmordred.task import Task
+from sirmordred.task_projects import TaskProjects
+
+
+logger = logging.getLogger(__name__)
+
+
+class TaskAutorefresh(Task):
+    """Refresh the last modified identities for all the backends."""
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        self.last_autorefresh_backend = {}
+
+    def is_backend_task(self):
+        return False
+
+    def _get_backend_sections(self):
+        """Get all the backends' sections enabled"""
+
+        backends = []
+        projects = TaskProjects.get_projects()
+
+        for pro in projects:
+            for sect in projects[pro].keys():
+                for backend_section in Config.get_backend_sections():
+                    if sect.startswith(backend_section) and backend_section in self.conf:
+                        backends.append(backend_section)
+
+        # Remove duplicates
+        backends = list(set(backends))
+        return backends
+
+    def __autorefresh(self, enrich_backend, backend_section, after):
+        """Refresh identities for a specific backend or study after a specific date"""
+
+        logger.info(f"[{backend_section}] Refreshing identities from {after}")
+
+        field_id = enrich_backend.get_field_unique_id()
+        author_fields = ["author_uuid"]
+        try:
+            meta_fields = enrich_backend.meta_fields
+            author_fields += meta_fields
+        except AttributeError:
+            pass
+
+        total_indiv = 0
+        total_items = 0
+        time_start = datetime.now()
+        for individuals in SortingHat.search_last_modified_identities(self.client, after):
+            eitems = refresh_identities(enrich_backend, author_fields=author_fields, individuals=individuals)
+            total_items += enrich_backend.elastic.bulk_upload(eitems, field_id)
+            total_indiv += len(individuals)
+            logger.debug(f"[{backend_section}] Individuals/items refreshed: {total_indiv}/{total_items}")
+
+        spent_time = str(datetime.now() - time_start).split('.')[0]
+        logger.info(f'[{backend_section}] Refreshed {total_indiv} individuals and {total_items} items in {spent_time}')
+
+    def __autorefresh_areas_of_code(self, after):
+        """Execute autorefresh for areas of code study if configured"""
+
+        if 'studies' not in self.conf['git'] or 'enrich_areas_of_code:git' not in self.conf['git']['studies']:
+            logger.info("Not doing autorefresh for studies, Areas of Code study is not active.")
+            return
+
+        aoc_index = self.conf['enrich_areas_of_code:git'].get('out_index', GitEnrich.GIT_AOC_ENRICHED)
+        if not aoc_index:
+            aoc_index = GitEnrich.GIT_AOC_ENRICHED
+
+        logger.debug(f"Autorefresh for Areas of Code study index: {aoc_index}")
+
+        ssl_context = create_ssl_context()
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+        es = Elasticsearch(hosts=[self.conf['es_enrichment']['url']],
+                           timeout=100, retry_on_timeout=True, ssl_context=ssl_context)
+
+        if not es.indices.exists(index=aoc_index):
+            logger.debug("Not doing autorefresh, index doesn't exist for Areas of Code study")
+            return
+
+        logger.debug("Doing autorefresh for Areas of Code study")
+
+        # Create a GitEnrich backend tweaked to work with AOC index
+        json_projects_map = self.conf['projects']['projects_file']
+        aoc_backend = GitEnrich(db_sortinghat=self.db_sh, json_projects_map=json_projects_map,
+                                db_user=self.db_user, db_password=self.db_password, db_host=self.db_host,
+                                db_port=self.db_port, db_path=self.db_path, db_ssl=self.db_ssl,
+                                db_verify_ssl=self.db_verify_ssl, db_tenant=self.db_tenant)
+        aoc_backend.mapping = None
+        aoc_backend.roles = ['author']
+        elastic_enrich = get_elastic(url=self.conf['es_enrichment']['url'], es_index=aoc_index,
+                                     clean=False, backend=aoc_backend)
+        aoc_backend.set_elastic(elastic_enrich)
+        if self.db_unaffiliate_group:
+            aoc_backend.unaffiliated_group = self.db_unaffiliate_group
+
+        self.__autorefresh(aoc_backend, 'git:aoc', after)
+
+    def __get_enrich_backend(self, backend):
+        connector = get_connector_from_name(backend)
+
+        json_projects_map = self.conf['projects']['projects_file']
+        enrich_backend = connector[2](db_sortinghat=self.db_sh, json_projects_map=json_projects_map,
+                                      db_user=self.db_user, db_password=self.db_password, db_host=self.db_host,
+                                      db_port=self.db_port, db_path=self.db_path, db_ssl=self.db_ssl,
+                                      db_verify_ssl=self.db_verify_ssl, db_tenant=self.db_tenant)
+        elastic_enrich = get_elastic(url=self.conf['es_enrichment']['url'],
+                                     es_index=self.conf[backend]['enriched_index'],
+                                     clean=False, backend=enrich_backend)
+        enrich_backend.set_elastic(elastic_enrich)
+
+        if 'pair-programming' in self.conf[backend]:
+            enrich_backend.pair_programming = self.conf[backend]['pair-programming']
+
+        if self.db_unaffiliate_group:
+            enrich_backend.unaffiliated_group = self.db_unaffiliate_group
+
+        return enrich_backend
+
+    def execute(self):
+        """Run autorefresh for all the backends"""
+
+        autorefresh = self.conf['es_enrichment']['autorefresh']
+        if not autorefresh or not self.client:
+            logger.info('Periodic autorefresh not active')
+            return
+
+        backends = self._get_backend_sections()
+        for backend_section in backends:
+            after = self.last_autorefresh_backend.get(backend_section, datetime.utcnow())
+            self.last_autorefresh_backend[backend_section] = datetime.utcnow()
+
+            logger.info(f'[{backend_section}] Periodic autorefresh start')
+            enrich_backend = self.__get_enrich_backend(backend_section)
+            self.__autorefresh(enrich_backend, backend_section, after)
+            logger.info(f'[{backend_section}] Periodic autorefresh end')
+
+        after = self.last_autorefresh_backend.get('git:aoc', datetime.utcnow())
+        self.last_autorefresh_backend['git:aoc'] = datetime.utcnow()
+
+        logger.info('[git:aoc] Periodic autorefresh for studies starts')
+        self.__autorefresh_areas_of_code(after)
+        logger.info('[git:aoc] Periodic autorefresh for studies ends')

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -302,8 +302,10 @@ class TaskEnrich(Task):
         logger.debug("Doing autorefresh for Areas of Code study")
 
         # Create a GitEnrich backend tweaked to work with AOC index
-        aoc_backend = GitEnrich(self.db_sh, cfg['projects']['projects_file'],
-                                self.db_user, self.db_password, self.db_host)
+        aoc_backend = GitEnrich(db_sortinghat=self.db_sh, json_projects_map=cfg['projects']['projects_file'],
+                                db_user=self.db_user, db_password=self.db_password, db_host=self.db_host,
+                                db_port=self.db_port, db_path=self.db_path, db_ssl=self.db_ssl,
+                                db_verify_ssl=self.db_verify_ssl, db_tenant=self.db_tenant)
         aoc_backend.mapping = None
         aoc_backend.roles = ['author']
         elastic_enrich = get_elastic(self.conf['es_enrichment']['url'],

--- a/tests/test_task_autorefresh.py
+++ b/tests/test_task_autorefresh.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Jose Javier Merchante <jjmerchante@bitergia.com>
+#
+
+import json
+import logging
+import sys
+import unittest
+
+import requests
+
+# Hack to make sure that tests import the right packages
+# due to setuptools behaviour
+sys.path.insert(0, '..')
+
+
+from grimoire_elk.enriched.sortinghat_gelk import SortingHat
+
+from sirmordred.config import Config
+from sirmordred.task_autorefresh import TaskAutorefresh
+from sirmordred.task_collection import TaskRawDataCollection
+from sirmordred.task_enrich import TaskEnrich
+from sirmordred.task_projects import TaskProjects
+
+from sortinghat.cli.client import SortingHatSchema
+
+from sgqlc.operation import Operation
+
+
+CONF_FILE = 'test.cfg'
+GIT_BACKEND_SECTION = 'git'
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+def read_file(filename, mode='r'):
+    with open(filename, mode) as f:
+        content = f.read()
+    return content
+
+
+class TestTaskAutorefresh(unittest.TestCase):
+    """Test TaskAutorefresh"""
+
+    @staticmethod
+    def get_organizations(client):
+        args = {
+            "page": 1,
+            "page_size": 10
+        }
+        op = Operation(SortingHatSchema.Query)
+        org = op.organizations(**args)
+        org.entities().name()
+        result = client.execute(op)
+        organizations = result['data']['organizations']['entities']
+
+        return organizations
+
+    @staticmethod
+    def get_individuals(client):
+        args = {
+            "page": 1,
+            "page_size": 1000
+        }
+        op = Operation(SortingHatSchema.Query)
+        individual = op.individuals(**args)
+        individual.entities().mk()
+        individual.entities().profile().name()
+        result = client.execute(op)
+
+        return result['data']['individuals']['entities']
+
+    @staticmethod
+    def delete_identity(client, args):
+        op = Operation(SortingHatSchema.SortingHatMutation)
+        identity = op.delete_identity(**args)
+        identity.uuid()
+        client.execute(op)
+
+    @staticmethod
+    def delete_organization(client, args):
+        op = Operation(SortingHatSchema.SortingHatMutation)
+        org = op.delete_organization(**args)
+        org.organization.name()
+        client.execute(op)
+
+    @staticmethod
+    def merge_individuals(client, args):
+        op = Operation(SortingHatSchema.SortingHatMutation)
+        merge = op.merge(**args)
+        merge.individual().mk()
+        client.execute(op)
+
+    @staticmethod
+    def add_identity(client, args):
+        op = Operation(SortingHatSchema.SortingHatMutation)
+        identity = op.add_identity(**args)
+        identity.uuid()
+        client.execute(op)
+
+    @staticmethod
+    def add_organization(client, args):
+        op = Operation(SortingHatSchema.SortingHatMutation)
+        org = op.add_organization(**args)
+        org.organization.name()
+        client.execute(op)
+
+    @staticmethod
+    def add_domain(client, args):
+        op = Operation(SortingHatSchema.SortingHatMutation)
+        dom = op.add_domain(**args)
+        dom.domain.domain()
+        client.execute(op)
+
+    def setUp(self):
+        config = Config(CONF_FILE)
+        task = TaskAutorefresh(config)
+
+        # Clean database
+        entities = SortingHat.unique_identities(task.client)
+        mks = [e['mk'] for e in entities]
+        for i in mks:
+            arg = {
+                'uuid': i
+            }
+            self.delete_identity(task.client, arg)
+
+        organizations = self.get_organizations(task.client)
+        for org in organizations:
+            self.delete_organization(task.client, org)
+
+        # Add identities and organizations
+        data = json.loads(read_file("data/task-identities-data.json"))
+
+        identities = data['identities']
+        for identity in identities:
+            self.add_identity(task.client, identity)
+
+        organizations = data['organizations']
+        for org in organizations:
+            self.add_organization(task.client, {"name": org['organization']})
+            self.add_domain(task.client, org)
+
+    def test_initialization(self):
+        """Test whether attributes are initialized"""
+
+        config = Config(CONF_FILE)
+        task = TaskAutorefresh(config)
+
+        self.assertEqual(task.config, config)
+
+    def test_is_backend_task(self):
+        """Test whether the Task is not a backend task"""
+
+        config = Config(CONF_FILE)
+        task = TaskAutorefresh(config)
+
+        self.assertFalse(task.is_backend_task())
+
+    def test_execute(self):
+        """Test whether the Task could be run"""
+
+        # Create a raw and enriched indexes
+        config = Config(CONF_FILE)
+
+        TaskProjects(config).execute()
+        backend_section = GIT_BACKEND_SECTION
+
+        task_collection = TaskRawDataCollection(config, backend_section=backend_section)
+        task_collection.execute()
+
+        task_enrich = TaskEnrich(config, backend_section=backend_section)
+        task_enrich.execute()
+
+        task_autorefresh = TaskAutorefresh(config)
+        task_autorefresh.config.set_param('es_enrichment', 'autorefresh', True)
+        # This does nothing because it uses now as from_date:
+        task_autorefresh.execute()
+
+        # Merge all the identities into user1
+        individuals = self.get_individuals(task_autorefresh.client)
+        to_uuid = '72f6fc79632080fc17dc8f83c0ddd5ff5b5e5005'
+        from_uuids = [ind['mk'] for ind in individuals if ind['mk'] != to_uuid]
+        arg = {'from_uuids': from_uuids, 'to_uuid': to_uuid}
+        self.merge_individuals(task_autorefresh.client, arg)
+
+        self.assertIsNone(task_autorefresh.execute())
+
+        # Check that the autorefresh went well
+        cfg = config.get_conf()
+        es_enrichment = cfg['es_enrichment']['url']
+        enrich_index = es_enrichment + "/" + cfg[GIT_BACKEND_SECTION]['enriched_index']
+
+        r = requests.get(enrich_index + "/_search", verify=False)
+        for hit in r.json()['hits']['hits']:
+            self.assertEqual(hit['_source']['author_uuid'], to_uuid)
+
+
+if __name__ == "__main__":
+    unittest.main(buffer=True, warnings='ignore')


### PR DESCRIPTION
Create a new Global task that runs an autorefresh process for all the backends continuously. The period this Task is executed depends on the configuration defined by `sortinghat.sleep_for`.