### PR TITLE
[CI] Update mariadb version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mysql:
-        image: mysql:5.7
+        image: mariadb:10.5
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     services:
       # How to use MySQL
       mysql:
-        image: mysql:5.7
+        image: mariadb:10.5
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:


### PR DESCRIPTION
This commit updates the version of the database for SortingHat. Now SortingHat requires Mariadb 10.4 or higher and MySQL 8.1 or higher.