### PR TITLE
[ci] Pin coveralls runner to 0.6.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,4 +107,8 @@ jobs:
         cd tests
         poetry run coverage run --source=sirmordred run_tests.py
     - name: Coveralls
-      uses: coverallsapp/github-action@f350da2c033043742f89e8c0b7b5145a1616da6d # v2.1.2
+      uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
+      with:
+        coverage-reporter-version: "v0.6.9"
+        flag-name: run ${{ join(matrix.*, ' - ') }}
+        parallel: true2


### PR DESCRIPTION
This commit tries to fix the problems we have
with coveralls. It fails and the tests don't
pass on GitHub Actions.