### PR TITLE
Include days spent in collection phase logs

### DIFF
--- a/releases/unreleased/days-in-collection-spent-time.yml
+++ b/releases/unreleased/days-in-collection-spent-time.yml
@@ -1,0 +1,8 @@
+---
+title: Days in collection spent time
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Include days in logs when the collection spent time is more than
+  one day.

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -22,12 +22,13 @@
 #
 
 import logging
-import time
 import traceback
 
 from grimoire_elk.elk import feed_backend
 from grimoire_elk.elastic_items import ElasticItems
 from grimoire_elk.elastic import ElasticSearch
+
+from grimoirelab_toolkit.datetime import datetime_utcnow
 
 from sirmordred.error import DataCollectionError
 from sirmordred.task import Task
@@ -74,7 +75,7 @@ class TaskRawDataCollection(Task):
             logging.info('%s collect disabled', self.backend_section)
             return errors
 
-        t2 = time.time()
+        time_start = datetime_utcnow()
         logger.info('[%s] collection phase starts', self.backend_section)
         print("Collection for {}: starting...".format(self.backend_section))
         clean = False
@@ -142,8 +143,7 @@ class TaskRawDataCollection(Task):
                 raise DataCollectionError('Failed to collect data from %s' % url)
             logger.info('[%s] collection finished for %s', self.backend_section, self.anonymize_url(repo))
 
-        t3 = time.time()
-        spent_time = time.strftime("%H:%M:%S", time.gmtime(t3 - t2))
+        spent_time = str(datetime_utcnow() - time_start).split('.')[0]
         logger.info('[%s] collection phase finished in %s',
                     self.backend_section, spent_time)
         print("Collection for {}: finished after {} hours".format(self.backend_section,


### PR DESCRIPTION
When the collection phase is finished and the spent time is more than one day, days are missing in the logs. It is now fixed and included in the logs.
