### PR TITLE
Fix identity refresh bug for all roles

### DIFF
--- a/releases/unreleased/identity-refresh-bug-for-some-items.yml
+++ b/releases/unreleased/identity-refresh-bug-for-some-items.yml
@@ -1,0 +1,12 @@
+---
+title: Identity refresh bug for some items
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Fix issue where some fields were not refreshed.
+  The bug occurred because the queries to OpenSearch filtered
+  items in which `author_uuid` was the individual pk, but not
+  when the `<role>_uuid` was the individual pk. That causes many
+  items that contain the `<role>_uuid` but not the `author_uuid`
+  not to be refreshed.

--- a/sirmordred/task_enrich.py
+++ b/sirmordred/task_enrich.py
@@ -249,12 +249,16 @@ class TaskEnrich(Task):
         next_autorefresh = self.__update_last_autorefresh()
 
         logger.debug('Getting last modified identities from SH since %s for %s', after, self.backend_section)
+
         author_fields = ["author_uuid"]
+        for role in enrich_backend.roles:
+            author_fields.append(role + '_uuid')
         try:
             meta_fields = enrich_backend.meta_fields
             author_fields += meta_fields
         except AttributeError:
             pass
+
         logger.debug("Refreshing identity ids for %s", self.backend_section)
         total = 0
         time_start = datetime.now()


### PR DESCRIPTION
This PR resolves an issue where role identities (like `reviewed_by` or `merged_by` among others) were not refreshed.

The bug occurred because the queries to OpenSearch filtered items in which `author_uuid` was the individual pk, but not when the `<role>_uuid` was the individual pk. That causes many items that contain the `<role>_uuid` but not the `author_uuid` not to be refreshed.

For example, the `Author` role was not affected because it matched `author_uuid`, but roles like `reviewed_by` did not match and were missed.

This PR depends on https://github.com/chaoss/grimoirelab-elk/pull/1163
This PR fixes https://github.com/chaoss/grimoirelab-elk/issues/1161 