### PR TITLE
Fix tasks without required SortingHat client

### DIFF
--- a/releases/unreleased/tasks-not-requiring-sortinghat-fixed.yml
+++ b/releases/unreleased/tasks-not-requiring-sortinghat-fixed.yml
@@ -1,0 +1,9 @@
+---
+title: Panels import bug and Micro Mordred failure
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  A bug was causing Panels to fail to import in Kibiter
+  and preventing micro Mordred from working. The issue
+  was in tasks that didn’t require a SortingHat client to run.

--- a/sirmordred/task_collection.py
+++ b/sirmordred/task_collection.py
@@ -41,8 +41,8 @@ logger = logging.getLogger(__name__)
 class TaskRawDataCollection(Task):
     """ Basic class shared by all collection tasks """
 
-    def __init__(self, config, backend_section=None, allowed_repos=None):
-        super().__init__(config)
+    def __init__(self, config, sortinghat_client=None, backend_section=None, allowed_repos=None):
+        super().__init__(config, sortinghat_client)
 
         self.backend_section = backend_section
         self.allowed_repos = set(allowed_repos) if allowed_repos else None

--- a/sirmordred/task_identities.py
+++ b/sirmordred/task_identities.py
@@ -38,8 +38,8 @@ logger = logging.getLogger(__name__)
 class TaskIdentitiesMerge(Task):
     """ Task for processing identities in SortingHat """
 
-    def __init__(self, conf, soringhat_client):
-        super().__init__(conf, soringhat_client)
+    def __init__(self, conf, sortinghat_client):
+        super().__init__(conf, sortinghat_client)
         self.last_autorefresh = datetime.utcnow()  # Last autorefresh date
 
     def is_backend_task(self):

--- a/sirmordred/task_panels.py
+++ b/sirmordred/task_panels.py
@@ -264,8 +264,8 @@ class TaskPanels(Task):
     # Panels to be uploaded always, no matter the data sources configured
     panels_common = panels_multi_ds + ["panels/json/about.json"]
 
-    def __init__(self, conf):
-        super().__init__(conf)
+    def __init__(self, conf, sortinghat_client=None):
+        super().__init__(conf, sortinghat_client)
         # Read panels and menu description from yaml file
         with open(self.conf['general']['menu_file'], 'r') as f:
             try:
@@ -473,8 +473,8 @@ class TaskPanelsMenu(Task):
         }
     }
 
-    def __init__(self, conf):
-        super().__init__(conf)
+    def __init__(self, conf, sortinghat_client=None):
+        super().__init__(conf, sortinghat_client)
         # Read panels and menu description from yaml file """
         with open(self.conf['general']['menu_file'], 'r') as f:
             try:


### PR DESCRIPTION
Tasks that didn’t require the SortingHat client were failing or receiving incorrect arguments because the client was being passed as the second argument. Since the client is required for all tasks, it has been added as an argument in the subclass constructors.