### PR TITLE
Include Python 3.12 in workflow tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     name: Python ${{ matrix.python-version }} for ES ${{ matrix.elasticsearch-version }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         elasticsearch-version: [6.8.6, 7.2.0]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     name: Python ${{ matrix.python-version }} for ES ${{ matrix.elasticsearch-version }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         elasticsearch-version: [6.8.6, 7.2.0]
     
     steps:


### PR DESCRIPTION
This PR adds Python 3.12 tests to the GitHub Actions workflows. These tests were missing during the migration from 3.8 to 3.9 due to incompatibilities with NumPy and the available packages at that time.