### PR TITLE
Fix invalid URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ but this allow to add the same source in different sections to enrich using the 
             "gerrit.chaoss.org --filter-raw=data.projects:CHAOSS"
         ]
         "git": [
-            "https:/github.com/chaoss/grimoirelab-perceval",
+            "https://github.com/chaoss/grimoirelab-perceval",
             "https://<username>:<api-token>@github.com/chaoss/grimoirelab-sirmordred"
         ],
         "github": [
-            "https:/github.com/chaoss/grimoirelab-perceval --filter-no-collection=true",
-            "https:/github.com/chaoss/grimoirelab-sirmordred  --labels=[example]"
+            "https://github.com/chaoss/grimoirelab-perceval --filter-no-collection=true",
+            "https://github.com/chaoss/grimoirelab-sirmordred  --labels=[example]"
         ]
     },
     "GrimoireLab": {
@@ -487,7 +487,7 @@ Commits from Git
 {
     "Chaoss": {
         "git": [
-            "https:/github.com/chaoss/grimoirelab-perceval",
+            "https://github.com/chaoss/grimoirelab-perceval",
             "https://<username>:<api-token>@github.com/chaoss/grimoirelab-sirmordred"
         ]
     }
@@ -529,8 +529,8 @@ Issues and PRs from GitHub
 {
     "Chaoss": {
         "github:issue": [
-            "https:/github.com/chaoss/grimoirelab-perceval",
-            "https:/github.com/chaoss/grimoirelab-sirmordred"
+            "https://github.com/chaoss/grimoirelab-perceval",
+            "https://github.com/chaoss/grimoirelab-sirmordred"
         ]
     }
 }
@@ -582,8 +582,8 @@ map_label = [others, bugs, enhancements]
 {
     "Chaoss": {
         "github:pull": [
-            "https:/github.com/chaoss/grimoirelab-perceval",
-            "https:/github.com/chaoss/grimoirelab-sirmordred"
+            "https://github.com/chaoss/grimoirelab-perceval",
+            "https://github.com/chaoss/grimoirelab-sirmordred"
         ]
     }
 }
@@ -623,8 +623,8 @@ The number of forks, stars, and subscribers in the repository.
 {
     "Chaoss": {
         "github:repo": [
-            "https:/github.com/chaoss/grimoirelab-perceval",
-            "https:/github.com/chaoss/grimoirelab-sirmordred"
+            "https://github.com/chaoss/grimoirelab-perceval",
+            "https://github.com/chaoss/grimoirelab-sirmordred"
         ]
     }
 }
@@ -702,8 +702,8 @@ to `true` in the `panels` section within the `setup.cfg`
 {
     "Chaoss": {
         "github2:issue": [
-            "https:/github.com/chaoss/grimoirelab-perceval",
-            "https:/github.com/chaoss/grimoirelab-sirmordred"
+            "https://github.com/chaoss/grimoirelab-perceval",
+            "https://github.com/chaoss/grimoirelab-sirmordred"
         ]
     }
 }
@@ -740,8 +740,8 @@ nlp_rest_url = http://localhost:2901
 {
     "Chaoss": {
         "github2:pull": [
-            "https:/github.com/chaoss/grimoirelab-perceval",
-            "https:/github.com/chaoss/grimoirelab-sirmordred"
+            "https://github.com/chaoss/grimoirelab-perceval",
+            "https://github.com/chaoss/grimoirelab-sirmordred"
         ]
     }
 }


### PR DESCRIPTION
Here is a (hopefully straightforward) fix to some URLs mentioned in the README.

By the way, I tried to follow the README.md to set up GrimoireLabs on some repositories, but I found the README quite confusing. For instance this section:

> In the section unknown the data source confluence will be enriched as the project main.
> In the projects.json above:
> * The data included in the repo `gerrit.chaoss.org` will be collected entirely since the
> repo is listed in the `unknown` section. However only the project `GrimoireLab` will be enriched as declared in the
> `GrimoireLab` section.
> * In the section `Chaoss` in the data source `github` the repository `grimoirelab-perceval` is not collected for
> raw index but it will enriched in the enriched index.
> * In the section `GrimoireLab` the metadata will showed in the enriched index as extra fields.
> * In the section `unknown` the data source `confluence` will be enriched as the project `main`.

I find that quite hard to parse… it seems that what happens to a project depends on distinct sections of this file?
What would help me would be a description of what the different JSON keys represent. What do the root JSON keys (`Chaoss`, `GrimoireLab`, `unknown`) correspond to?
The examples would perhaps be easier to understand if they referred to Git projects that have nothing to do with GrimoireLab / CHAOSS (you could pick, say, https://github.com/wesnoth/wesnoth and a couple of other projects). I understand it's fun to have GrimoireLab analyze itself but it doesn't really help with distinguishing what settings belong to GrimoireLab the software that I'm running and to GrimoireLab the git project I'm analyzing.