### PR TITLE
Add GitHub issue aliases

### DIFF
--- a/aliases.json
+++ b/aliases.json
@@ -314,6 +314,52 @@
       }
     ]
   },
+  "github:issue": {
+    "raw": [
+      {
+        "alias": "github-raw"
+      }
+    ],
+    "enrich": [
+      {
+        "alias": "github_issues"
+      },
+      {
+        "alias": "affiliations"
+      },
+      {
+        "alias": "all_enriched"
+      },
+      {
+        "alias": "all_enriched_tickets",
+        "filter" : {
+              "terms" : {
+                "pull_request" : ["false"]
+              }
+            }
+      },
+      {
+        "alias": "github_issues_onion-src",
+        "filter" : {
+            "terms" : {
+            "pull_request" : [
+                "false"
+                ]
+            }
+        }
+      },
+      {
+        "alias": "github_prs_onion-src",
+        "filter" : {
+            "terms" : {
+            "pull_request" : [
+                "true"
+            ]
+          }
+        }
+      }
+    ]
+  },
   "gitlab:issue": {
     "raw": [
       {


### PR DESCRIPTION
This PR adds aliases for the [github:issue] category in `aliases.json` file, similar to those for [github]. These aliases improve organization and filtering of issues and pull requests and prevent failures when users define the [github:issue] key as described in several parts of the documentation.