### PR TITLE
Add support for external secrets managers from Grimoirelab-Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ SirMordred is the tool used to coordinate the execution of the GrimoireLab platf
 ## Contents
 
 * [Setup.cfg](#setupcfg-)
+* [Secrets Manager](#secrets-manager-)
 * [Projects.json](#projectsjson-)
 * [Supported data sources](#supported-data-sources-)
 * [Micro Mordred](#micro-mordred-)
@@ -42,6 +43,7 @@ new data sources, thus you need to manually delete the dashboards `Data Status` 
  * **menu_file** (str: ./menu.yaml): YAML file to define the menus to be shown in Kibiter
  * **global_data_sources** (list: bugzilla, bugzillarest, confluence, discourse, gerrit, jenkins, jira): List of data sources collected globally, they are declared in the section 'unknown' of the projects.json
  * **retention_time** (int: None): the maximum number of minutes wrt the current date to retain the data
+ * **secrets_manager** (str: None): Secrets manager provider (`bitwarden` or `hashicorp`) to delegate backend credential resolution to Perceval. See [Secrets Manager](#secrets-manager-).
  * **update_hour** (int: None): The hour of the day the tasks will run ignoring `min_update_delay` (collect, enrich ...)
 ### [panels]
 
@@ -122,6 +124,33 @@ Note that some backend sections allow to specify specific enrichment options, wh
 A template of a study section is shown above. A complete list of studies parameters is available at:
 
 * https://github.com/chaoss/grimoirelab-sirmordred/blob/main/tests/test_studies.cfg
+
+## Secrets Manager [&uarr;](#contents)
+
+SirMordred can delegate backend credential resolution to Perceval's secrets manager support, so tokens and passwords do not need to live in `setup.cfg`. Supported providers are Bitwarden and HashiCorp Vault.
+
+**1. Enable a provider in `[general]`:**
+
+```ini
+[general]
+secrets_manager = bitwarden   # or: hashicorp
+```
+
+**2. Opt each backend in via a `[<backend>:credentials]` subsection:**
+
+```ini
+[github:credentials]
+item-name = github-prod        # vault entry name; defaults to backend name
+```
+
+**3. Provide provider auth via environment variables** (read by Perceval, not by SirMordred):
+
+| Provider | Variables |
+|---|---|
+| Bitwarden | `PERCEVAL_BW_CLIENT_ID`, `PERCEVAL_BW_CLIENT_SECRET`, `PERCEVAL_BW_MASTER_PASSWORD` |
+| HashiCorp Vault | `PERCEVAL_VAULT_URL`, `PERCEVAL_VAULT_TOKEN` |
+
+The vault entry referenced by `item-name` must store the credential under one of Perceval's standard field names (`user`, `password`, `api_token`, `email`, `access_token`, `user_id`). See the [Perceval secrets manager docs](https://github.com/chaoss/grimoirelab-perceval/blob/main/docs/perceval/secrets-manager.md) for installation, supported backends, and the full field reference.
 
 ## Projects.json [&uarr;](#contents)
 

--- a/sirmordred/config.py
+++ b/sirmordred/config.py
@@ -163,6 +163,16 @@ class Config():
                     "default": None,
                     "type": int,
                     "description": "The maximum number of minutes wrt the current date to retain the data"
+                },
+                "secrets_manager": {
+                    "optional": True,
+                    "default": None,
+                    "type": str,
+                    "description": "Secrets manager provider ('bitwarden' or 'hashicorp'). "
+                                   "If set, backend sections with a [<backend>:credentials] "
+                                   "subsection will fetch credentials via this provider. "
+                                   "Provider auth credentials are read from PERCEVAL_BW_* / "
+                                   "PERCEVAL_VAULT_* environment variables."
                 }
             }
         }

--- a/sirmordred/task.py
+++ b/sirmordred/task.py
@@ -159,6 +159,18 @@ class Task():
                 params.append("--" + p)
                 params.append(str(section_param))
 
+        # If a secrets manager is configured and this backend has a
+        # [<backend>:credentials] subsection, delegate credential
+        # resolution to perceval by appending its CLI flags. Provider
+        # auth (bw/vault) is read by perceval from PERCEVAL_BW_* /
+        # PERCEVAL_VAULT_* environment variables.
+        raw_sections = self.conf.conf
+        manager = raw_sections.get('general', {}).get('secrets_manager')
+        creds_section = raw_sections.get(f'{backend}:credentials')
+        if manager and creds_section is not None:
+            item_name = creds_section.get('item-name', backend)
+            params += ['--secrets-manager', manager, '--secret-name', item_name]
+
         return params
 
     def _get_collection_url(self):

--- a/sirmordred/utils/setup.cfg
+++ b/sirmordred/utils/setup.cfg
@@ -26,6 +26,15 @@ bulk_size = 100
 scroll_size = 100
 menu_file = ../../menu.yaml
 aliases_file = ../../aliases.json
+# Enable a secrets manager for backend credentials. Set to 'bitwarden'
+# or 'hashicorp' to delegate credential retrieval to perceval. Provider
+# auth credentials are read from PERCEVAL_BW_CLIENT_ID,
+# PERCEVAL_BW_CLIENT_SECRET, PERCEVAL_BW_MASTER_PASSWORD or
+# PERCEVAL_VAULT_URL, PERCEVAL_VAULT_TOKEN environment variables.
+# See grimoirelab-perceval/docs/perceval/secrets-manager.md for the
+# expected vault field names (user, password, api_token, email,
+# access_token, user_id).
+# secrets_manager = bitwarden
 
 [projects]
 projects_file = ./projects.json
@@ -77,6 +86,12 @@ enriched_index = git_chaoss_enriched
 latest-items = true
 category = commit
 studies = [enrich_demography:git, enrich_areas_of_code:git, enrich_onion:git]
+
+# Example: opt this backend into the secrets manager configured in
+# [general] secrets_manager. The vault entry named by 'item-name'
+# must store an 'api_token' field with the GitHub token.
+# [github:credentials]
+# item-name = github
 
 [github]
 raw_index = github_issues_chaoss

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,6 +33,7 @@ from sirmordred.config import (Config, logger)
 CONF_FULL = 'test.cfg'
 CONF_SLIM = 'test_studies.cfg'
 CONF_WRONG = 'test_wrong.cfg'
+CONF_CREDENTIALS = 'test_credentials.cfg'
 
 
 class TestConfig(unittest.TestCase):
@@ -365,6 +366,42 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(config.get('backend', 'hiya!'), 'hiya!')
         self.assertEqual(config.get('backend:param1'), config['backend:param1'])
         self.assertEqual(config.get('backend:param1', 'inspecific string'), config['backend:param1'])
+
+    def test_secrets_manager_default_is_none(self):
+        """When [general] secrets_manager is absent, check_config applies
+        the default (None) defined in the schema."""
+
+        config = Config(CONF_FULL)
+
+        self.assertIsNone(config.conf['general']['secrets_manager'])
+
+    def test_secrets_manager_string_value(self):
+        """[general] secrets_manager parses as a plain string."""
+
+        config = Config(CONF_CREDENTIALS)
+
+        self.assertEqual(config.conf['general']['secrets_manager'], 'bitwarden')
+
+    def test_credentials_subsection_check_config_passes(self):
+        """A [<backend>:credentials] subsection does not trip check_config
+        and survives parsing intact."""
+
+        config = Config(CONF_CREDENTIALS)
+
+        self.assertIn('github:credentials', config.conf)
+        self.assertEqual(
+            config.conf['github:credentials']['item-name'],
+            'github-prod',
+        )
+
+    def test_credentials_subsection_not_leaked_by_get_backend_section(self):
+        """get_backend_section('github') must not pull keys from the
+        [github:credentials] subsection into the composed dict."""
+
+        config = Config(CONF_CREDENTIALS)
+        composed = config.get_backend_section('github')
+
+        self.assertNotIn('item-name', composed)
 
 
 if __name__ == "__main__":

--- a/tests/test_credentials.cfg
+++ b/tests/test_credentials.cfg
@@ -1,0 +1,77 @@
+#
+# Test config for credential manager integration. Mirrors test.cfg with
+# [general] secrets_manager = bitwarden and a [github:credentials]
+# subsection so dispatch tests can exercise the perceval flag emission.
+#
+
+[general]
+short_name = Grimoire
+update = false
+min_update_delay = 10
+update_hour = 9
+debug = true
+logs_dir = logs
+bulk_size = 100
+scroll_size = 100
+secrets_manager = bitwarden
+
+[projects]
+projects_file = test-projects.json
+
+[es_collection]
+url = http://localhost:9200
+
+[es_enrichment]
+url = http://localhost:9200
+autorefresh = false
+
+[sortinghat]
+host = 127.0.0.1
+user = admin
+password = admin
+port = 8000
+path = api/
+ssl = false
+database = test_sh
+affiliate = true
+unaffiliated_group = Unknown
+autoprofile = [customer,git,github]
+matching = [email]
+sleep_for = 120
+
+[panels]
+kibiter_time_from= "now-30y"
+kibiter_default_index= "git"
+kibiter_url = http://localhost:5601
+
+[phases]
+collection = true
+identities = true
+enrichment = true
+panels = true
+
+[git]
+raw_index = git_test-raw
+enriched_index = git_test
+studies = []
+
+[github:credentials]
+item-name = github-prod
+
+[github]
+raw_index = github_test-raw
+enriched_index = github_test
+api-token = XXXXX
+sleep-for-rate = true
+archive-path = /tmp/test_github_archive
+category = issue
+sleep-time = 300
+
+[github:pull]
+raw_index = github_test-raw-pull
+enriched_index = github_test-pull
+api-token = XXXXX
+sleep-for-rate = true
+archive-path = /tmp/test_github_archive
+category = pull_request
+sleep-time = 300

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -23,6 +23,7 @@
 import os
 import json
 import sys
+import tempfile
 import unittest
 
 
@@ -36,9 +37,14 @@ from sirmordred.task import Task
 from sortinghat.cli.client import SortingHatClient
 
 CONF_FILE = 'test.cfg'
+CONF_CREDENTIALS = 'test_credentials.cfg'
 BACKEND_NAME = 'stackexchange'
 COLLECTION_URL_STACKEXCHANGE = 'http://127.0.0.1:9200'
 REPO_NAME = 'https://stackoverflow.com/questions/tagged/ovirt'
+GITHUB_REPO_URL = 'https://github.com/example/repo'
+GIT_REPO_URL = 'https://github.com/example/repo.git'
+SECRETS_MANAGER_FLAGS = ['--secrets-manager', 'bitwarden',
+                         '--secret-name', 'github-prod']
 
 
 def read_file(filename, mode='r'):
@@ -137,6 +143,87 @@ class TestTask(unittest.TestCase):
         task.backend_section = "stackexchange"
 
         self.assertEqual(task._get_collection_url(), COLLECTION_URL_STACKEXCHANGE)
+
+
+class TestComposePercevalParamsCredentials(unittest.TestCase):
+    """Tests for the secrets-manager flag emission in
+    `Task._compose_perceval_params`.
+
+    These tests do not need a live SortingHat: `_compose_perceval_params`
+    never touches the client, and `Task.__init__` accepts
+    `sortinghat_client=None` and reads optional [sortinghat] config from
+    the fixture without opening a connection. Keeping them isolated from
+    `TestTask`'s SortingHat-dependent setUp makes the new behaviour
+    verifiable in any environment.
+    """
+
+    def test_secrets_manager_appended(self):
+        """Flags are appended when [general] secrets_manager is set and
+        the backend has a [<backend>:credentials] section."""
+
+        config = Config(CONF_CREDENTIALS)
+        task = Task(config, sortinghat_client=None)
+
+        params = task._compose_perceval_params('github', GITHUB_REPO_URL)
+
+        self.assertEqual(params[-4:], SECRETS_MANAGER_FLAGS)
+
+    def test_default_item_name(self):
+        """When [<backend>:credentials] omits item-name, --secret-name
+        defaults to the base backend name."""
+
+        original = read_file(CONF_CREDENTIALS)
+        patched = original.replace('item-name = github-prod\n', '')
+        tmp_path = tempfile.mktemp(prefix='test_credentials_', suffix='.cfg')
+        with open(tmp_path, 'w') as f:
+            f.write(patched)
+
+        try:
+            config = Config(tmp_path)
+            task = Task(config, sortinghat_client=None)
+            params = task._compose_perceval_params('github', GITHUB_REPO_URL)
+            self.assertEqual(
+                params[-4:],
+                ['--secrets-manager', 'bitwarden', '--secret-name', 'github'],
+            )
+        finally:
+            os.remove(tmp_path)
+
+    def test_no_secrets_manager(self):
+        """Without [general] secrets_manager set, no flags are appended
+        even if a [<backend>:credentials] section happens to exist."""
+
+        config = Config(CONF_FILE)
+        task = Task(config, sortinghat_client=None)
+
+        params = task._compose_perceval_params('github', GITHUB_REPO_URL)
+
+        self.assertNotIn('--secrets-manager', params)
+        self.assertNotIn('--secret-name', params)
+
+    def test_no_credentials_section(self):
+        """With secrets_manager set but no [<backend>:credentials], no
+        flags are appended for that backend."""
+
+        config = Config(CONF_CREDENTIALS)
+        task = Task(config, sortinghat_client=None)
+
+        # test_credentials.cfg has [git] but no [git:credentials].
+        params = task._compose_perceval_params('git', GIT_REPO_URL)
+
+        self.assertNotIn('--secrets-manager', params)
+        self.assertNotIn('--secret-name', params)
+
+    def test_parameterized_backend_uses_base(self):
+        """For a parameterized backend section like 'github:pull', the
+        credentials subsection is resolved against the base backend."""
+
+        config = Config(CONF_CREDENTIALS)
+        task = Task(config, sortinghat_client=None)
+
+        params = task._compose_perceval_params('github:pull', GITHUB_REPO_URL)
+
+        self.assertEqual(params[-4:], SECRETS_MANAGER_FLAGS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Integrate Toolkit credential_manager module so backend credentials (perceval, sortinghat) can be resolved at runtime instead of being stored in setup.cfg in plain text.
  
  - Add [general] secrets_manager config key (bitwarden or hashicorp) in config.py
  - Add [<backend>:credentials] subsection with item-name for per-backend opt-in in setup.cfg
  - Emit --secrets-manager and --secret-name flags from Task._compose_perceval_params, reading raw sections to avoid Config composition merging credential keys into backend params
  - Tests for config parsing and parameter composition (default item-name, parameterized backend sections, no-manager path)
  - Example fixture tests/test_credentials.cfg and commented usage in sirmordred/utils/setup.cfg
  - Added informtion in README